### PR TITLE
Do not include leading '/' in object names

### DIFF
--- a/oioswift/autocontainer.py
+++ b/oioswift/autocontainer.py
@@ -42,7 +42,8 @@ class AutocontainerMiddleware(object):
             return self.app(env, start_response)
 
         if self.default_account:
-            obj = env.get('PATH_INFO').strip('/')
+            # Remove leading '/' to be consistent with split_path()
+            obj = env.get('PATH_INFO').lstrip('/')
             acc = self.default_account
         else:
             acc, obj = split_path(env.get('PATH_INFO'), 1, 2, True)
@@ -54,7 +55,7 @@ class AutocontainerMiddleware(object):
 
 
 def filter_factory(global_config, **local_config):
-    conf = global_conf.copy()
+    conf = global_config.copy()
     conf.update(local_config)
 
     default_account = conf.get('sds_default_account')

--- a/oioswift/hashedcontainer.py
+++ b/oioswift/hashedcontainer.py
@@ -67,19 +67,19 @@ class HashedcontainerMiddleware(object):
 
         path = env.get('PATH_INFO')
         account = self.account
-        obj = path
+        # Remove leading '/' to be consistent with split_path()
+        obj = path.lstrip('/')
 
         if self.strip_v1:
-            version, tail = split_path(obj, 1, 2, True)
+            version, tail = split_path(path, 1, 2, True)
             if version == 'v1':
-                obj = '/' + tail
+                obj = tail
 
         if self.account_first:
-            account, tail = split_path(obj, 1, 2, True)
-            obj = '/' + tail
+            account, tail = split_path(path, 1, 2, True)
+            obj = tail
 
         container = self.con_builder(obj)
-        obj = obj.strip('/')
         path = "/v1/%s/%s/%s" % (account, container, obj)
         env['PATH_INFO'] = path
         return self.app(env, start_response)


### PR DESCRIPTION
Previously the leading '/' was not included in object names but included
while computing autocontainer name.