### PR TITLE
Allow setting connection pools options

### DIFF
--- a/conf/default.cfg
+++ b/conf/default.cfg
@@ -17,14 +17,22 @@ sds_proxy_url = http://127.0.0.1:6000
 sds_default_account = myaccount
 
 # The timeout (in seconds, float) to establish a connection to a rawx
-#connection_timeout=2
+#sds_connection_timeout=2
 
 # The timeout (in seconds, float) to read a chunk of data from a rawx
 # and to read data from the client when uploading
-#read_timeout=5
+#sds_read_timeout=5
 
 # The timeout (in seconds, float) to write a chunk of data to a rawx
-#write_timeout=5
+#sds_write_timeout=5
+
+# Python Requests options.
+# See http://docs.python-requests.org/en/master/api/#requests.adapters.HTTPAdapter
+# You can increase sds_pool_maxsize if you get errors like
+# "Connection pool is full, discarding connection".
+#sds_pool_connections=10
+#sds_pool_maxsize=10
+#sds_max_retries=0
 
 [pipeline:main]
 pipeline = catch_errors hashedcontainer gatekeeper healthcheck proxy-logging cache bulk tempurl ratelimit crossdomain tempauth staticweb container-quotas account-quotas slo dlo versioned_writes proxy-logging proxy-server

--- a/oioswift/server.py
+++ b/oioswift/server.py
@@ -50,10 +50,16 @@ class Application(SwiftApplication):
                                   container_ring=container_ring)
         if conf is None:
             conf = {}
-        self.sds_namespace = conf.get('sds_namespace', 'OPENIO')
-        self.sds_proxy_url = conf.get('sds_proxy_url', 'http://127.0.0.1:6000')
+        sds_conf = {k[4:]: v
+                    for k, v in conf.iteritems()
+                    if k.startswith("sds_")}
+        # Mandatory, raises KeyError
+        sds_namespace = sds_conf['namespace']
+        sds_conf.pop('namespace')  # removed to avoid unpacking conflict
+        # Loaded by ObjectStorageAPI if None
+        sds_proxy_url = sds_conf.get('proxy_url')
         self.storage = storage or \
-            ObjectStorageAPI(self.sds_namespace, self.sds_proxy_url, **conf)
+            ObjectStorageAPI(sds_namespace, sds_proxy_url, **sds_conf)
 
 
 def app_factory(global_conf, **local_conf):


### PR DESCRIPTION
This changes a little the configuration file: SDS options are now
all prefixed with "sds_".