### PR TITLE
Remove an unwanted urlencode of properties in HEAD and GET

### DIFF
--- a/oioswift/proxy/controllers/obj.py
+++ b/oioswift/proxy/controllers/obj.py
@@ -17,7 +17,6 @@
 import mimetypes
 import time
 import math
-from urllib import quote
 
 from swift import gettext_ as _
 from swift.common.utils import (
@@ -41,7 +40,6 @@ from swift.proxy.controllers.obj import BaseObjectController as \
 
 from oioswift.common.storage_policy import POLICIES
 from oio.common import exceptions
-from oio.common.utils import quote as oio_quote
 from oio.common.http import ranges_from_http_header
 from oioswift.utils import IterO
 
@@ -169,7 +167,7 @@ class ObjectController(BaseObjectController):
             for k, v in properties.iteritems():
                 if is_sys_or_user_meta('object', k) or \
                         k.lower() in self.allowed_headers:
-                            resp.headers[str(k)] = oio_quote(v)
+                            resp.headers[str(k)] = v
         resp.headers['etag'] = metadata['hash'].lower()
         ts = Timestamp(metadata['ctime'])
         resp.last_modified = math.ceil(float(ts))

--- a/oioswift/server.py
+++ b/oioswift/server.py
@@ -49,7 +49,7 @@ class Application(SwiftApplication):
                                   account_ring=account_ring,
                                   container_ring=container_ring)
         if conf is None:
-            conf = {}
+            conf = dict()
         sds_conf = {k[4:]: v
                     for k, v in conf.iteritems()
                     if k.startswith("sds_")}
@@ -57,7 +57,7 @@ class Application(SwiftApplication):
         sds_namespace = sds_conf['namespace']
         sds_conf.pop('namespace')  # removed to avoid unpacking conflict
         # Loaded by ObjectStorageAPI if None
-        sds_proxy_url = sds_conf.get('proxy_url')
+        sds_proxy_url = sds_conf.pop('proxy_url', None)
         self.storage = storage or \
             ObjectStorageAPI(sds_namespace, sds_proxy_url, **sds_conf)
 


### PR DESCRIPTION
Since property values are not urldecoded during PUT, they should
not be urlencoded during HEAD and GET.