### PR TITLE
Fix unit tests

### DIFF
--- a/oioswift/proxy/controllers/obj.py
+++ b/oioswift/proxy/controllers/obj.py
@@ -36,7 +36,7 @@ from swift.proxy.controllers.obj import BaseObjectController as \
 
 from oio.common import exceptions
 from oio.common.http import ranges_from_http_header
-from oio.common.green import ClientReadTimeout
+from oio.common.green import SourceReadTimeout
 
 
 class ObjectControllerRouter(object):
@@ -288,7 +288,7 @@ class ObjectController(BaseObjectController):
                 etag=req.headers.get('etag', '').strip('"'), metadata=metadata)
         except exceptions.PreconditionFailed:
             raise HTTPPreconditionFailed(request=req)
-        except ClientReadTimeout as err:
+        except SourceReadTimeout as err:
             self.app.logger.warning(
                 _('ERROR Client read timeout (%ss)'), err.seconds)
             self.app.logger.increment('client_timeouts')

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -3,9 +3,12 @@ import sys
 import logging
 from collections import defaultdict
 from contextlib import contextmanager
+from mock import MagicMock as Mock
 from swift.common import utils
 from swift.common.utils import NOTICE
-from oiopy.object_storage import ObjectStorageAPI
+from oio.api.object_storage import ObjectStorageApi
+from oio.account.client import AccountClient
+from oio.container.client import ContainerClient
 
 
 class FakeMemcache(object):
@@ -38,9 +41,11 @@ class FakeMemcache(object):
         return True
 
 
-class FakeStorageAPI(ObjectStorageAPI):
-    def __init__(*args, **kwargs):
-        pass
+class FakeStorageAPI(ObjectStorageApi):
+    def __init__(self, *args, **kwargs):
+        self.account = Mock(AccountClient)
+        self.container = Mock(ContainerClient)
+        self.__dict__.update(kwargs)
 
 
 class DebugLogAdapter(utils.LogAdapter):

--- a/tests/unit/controllers/test_container.py
+++ b/tests/unit/controllers/test_container.py
@@ -16,6 +16,12 @@ class TestContainerController(unittest.TestCase):
 
         self.logger = debug_logger('proxy-server')
         self.storage = FakeStorageAPI()
+        self.storage.account.account_show = Mock(return_value={
+            'containers': 0,
+            'objects': 0,
+            'bytes': 0,
+            'ctime': 0,
+            'metadata': {}})
 
         self.account_info = {
             'status': 200,
@@ -27,7 +33,7 @@ class TestContainerController(unittest.TestCase):
         }
 
         self.app = proxy_server.Application(
-            None, FakeMemcache(), account_ring=FakeRing(),
+            {'sds_namespace': 'NS'}, FakeMemcache(), account_ring=FakeRing(),
             container_ring=FakeRing(), storage=self.storage,
             logger=self.logger)
 
@@ -51,34 +57,35 @@ class TestContainerController(unittest.TestCase):
 
     def test_container_info(self):
         req = Request.blank('/v1/a/c', {'PATH_INFO': '/v1/a/c'}, method='HEAD')
-        self.storage.container_show = Mock(return_value={})
+        self.storage.container.container_show = Mock(return_value={})
         resp = req.get_response(self.app)
         self.assertEqual(2, resp.status_int // 100)
-        self.assertTrue('swift.container/a/c' in resp.environ)
+        self.assertIn('swift.infocache', resp.environ)
+        self.assertIn('container/a/c', resp.environ['swift.infocache'])
         self.assertEqual(
             headers_to_container_info(resp.headers, resp.status_int),
-            resp.environ['swift.container/a/c'])
+            resp.environ['swift.infocache']['container/a/c'])
 
     def test_swift_owner(self):
-        owner_headers = {
+        owner_headers = {'properties': {
             'x-container-read': 'value', 'x-container-write': 'value',
-            'x-container-sync-key': 'value', 'x-container-sync-to': 'value'}
+            'x-container-sync-key': 'value', 'x-container-sync-to': 'value'}}
         req = Request.blank('/v1/a/c', method='HEAD')
-        meta = {}
-        meta.update(('user.' + k, v) for k, v in owner_headers.iteritems())
-        self.storage.container_show = Mock(return_value=meta)
+        self.storage.container.container_get_properties = Mock(
+                return_value=owner_headers)
         resp = req.get_response(self.app)
         self.assertEqual(2, resp.status_int // 100)
-        for k in owner_headers:
+        for k in owner_headers['properties']:
             self.assertTrue(k not in resp.headers)
 
         req = Request.blank(
             '/v1/a/c', environ={'swift_owner': True}, method='HEAD')
-        self.storage.container_show = Mock(return_value=meta)
+        self.storage.container.container_get_properties = Mock(
+                return_value=owner_headers)
         resp = req.get_response(self.app)
         self.assertEqual(2, resp.status_int // 100)
-        for k in owner_headers:
-            self.assertTrue(k in resp.headers)
+        for k in owner_headers['properties']:
+            self.assertIn(k, resp.headers)
 
     def test_sys_meta_headers_PUT(self):
         sys_meta_key = '%stest' % get_sys_meta_prefix('container')
@@ -89,11 +96,12 @@ class TestContainerController(unittest.TestCase):
                    user_meta_key: 'bar',
                    'x-timestamp': '1.0'}
         req = Request.blank('/v1/a/c', headers=hdrs_in, method='PUT')
-        self.storage.container_create = Mock()
+        self.storage.container.container_create = Mock()
         req.get_response(self.app)
-        meta = self.storage.container_create.call_args[1]['metadata']
-        self.assertEqual(meta['user.' + sys_meta_key], 'foo')
-        self.assertEqual(meta['user.' + user_meta_key], 'bar')
+        meta = \
+            self.storage.container.container_create.call_args[1]['properties']
+        self.assertEqual(meta[sys_meta_key], 'foo')
+        self.assertEqual(meta[user_meta_key], 'bar')
 
     def test_sys_meta_headers_POST(self):
         # check that headers in sys meta namespace make it through
@@ -105,8 +113,9 @@ class TestContainerController(unittest.TestCase):
                    user_meta_key: 'bar',
                    'x-timestamp': '1.0'}
         req = Request.blank('/v1/a/c', headers=hdrs_in, method='POST')
-        self.storage.container_set_properties = Mock()
+        self.storage.container.container_set_properties = Mock(
+                return_value="")
         req.get_response(self.app)
-        meta = self.storage.container_set_properties.call_args[0][2]
-        self.assertEqual(meta['user.' + sys_meta_key], 'foo')
-        self.assertEqual(meta['user.' + user_meta_key], 'bar')
+        meta = self.storage.container.container_set_properties.call_args[0][2]
+        self.assertEqual(meta[sys_meta_key], 'foo')
+        self.assertEqual(meta[user_meta_key], 'bar')

--- a/tests/unit/controllers/test_obj.py
+++ b/tests/unit/controllers/test_obj.py
@@ -1,10 +1,15 @@
+# These tests make a lot of assumptions about the inner working of oio-sds
+# Python API, and thus will stop working at some point.
+
+import unittest
 from mock import MagicMock as Mock
 from mock import patch
-import unittest
 
-from oiopy import fakes
-from oiopy import exceptions as exc
 from eventlet import Timeout
+
+from oio.common import exceptions as exc
+from oio.common import green as oiogreen
+from oio.common.http import CustomHttpConnection
 from swift.proxy.controllers.base import get_info as _real_get_info
 from swift.common.swob import Request
 from oioswift.common.ring import FakeRing
@@ -19,12 +24,29 @@ def fake_stream(l):
 
 def fake_prepare_meta():
     return {
-        'x-oio-content-meta-id': '',
-        'x-oio-content-meta-version': '',
-        'x-oio-content-meta-policy': '',
         'x-oio-content-meta-mime-type': '',
-        'x-oio-content-meta-chunk-method': '',
+        'id': '',
+        'version': 42,
+        'policy': 'SINGLE',
+        'chunk_method': 'plain/nb_copy=1',
+        'chunk_size': 1048576,
     }
+
+
+class FakePutResponse(object):
+    def __init__(self, **kwargs):
+        self.status = 201
+        self.headers = dict()
+        self.__dict__.update(kwargs)
+
+    def getheader(self, header):
+        return self.headers.get(header)
+
+
+def fake_http_connect(*args, **kwargs):
+    conn = Mock(CustomHttpConnection)
+    conn.getresponse = Mock(return_value=FakePutResponse())
+    return conn
 
 
 class PatchedObjControllerApp(proxy_server.Application):
@@ -59,26 +81,40 @@ class TestObjectController(unittest.TestCase):
     def setUp(self):
 
         self.logger = debug_logger('proxy-server')
-        self.storage = FakeStorageAPI()
+        self.storage = FakeStorageAPI(
+            namespace='NS', timeouts={})
 
         self.app = PatchedObjControllerApp(
-            None, FakeMemcache(), account_ring=FakeRing(),
+            {'sds_namespace': "NS"}, FakeMemcache(), account_ring=FakeRing(),
             container_ring=FakeRing(), storage=self.storage,
             logger=self.logger)
         self.app.container_info = dict(self.container_info)
+        self.storage.account.account_show = Mock(
+            return_value={
+                'ctime': 0,
+                'containers': 1,
+                'objects': 1,
+                'bytes': 2,
+                'metadata': {}
+                })
+        self.storage.container.container_get_properties = Mock(
+                return_value={'properties': {}, 'system': {}})
 
     def test_DELETE_simple(self):
         req = Request.blank('/v1/a/c/o', method='DELETE')
         self.storage.object_delete = Mock()
         resp = req.get_response(self.app)
-        self.storage.object_delete.assert_called_once_with('a', 'c', 'o')
+        self.storage.object_delete.assert_called_once_with(
+            'a', 'c', 'o')
         self.assertEqual(resp.status_int, 204)
 
     def test_DELETE_not_found(self):
         req = Request.blank('/v1/a/c/o', method='DELETE')
         self.storage.object_delete = Mock(side_effect=exc.NoSuchObject)
         resp = req.get_response(self.app)
-        self.assertEqual(resp.status_int, 404)
+        self.storage.object_delete.assert_called_once_with(
+            'a', 'c', 'o')
+        self.assertEqual(resp.status_int, 204)
 
     def test_HEAD_simple(self):
         req = Request.blank('/v1/a/c/o', method='HEAD')
@@ -86,10 +122,13 @@ class TestObjectController(unittest.TestCase):
             'ctime': 0,
             'hash': 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
             'length': 1,
+            'deleted': False,
+            'version': 42,
         }
         self.storage.object_show = Mock(return_value=ret_val)
         resp = req.get_response(self.app)
-        self.storage.object_show.assert_called_once_with('a', 'c', 'o')
+        self.storage.object_show.assert_called_once_with(
+            'a', 'c', 'o')
         self.assertEqual(resp.status_int, 200)
         self.assertIn('Accept-Ranges', resp.headers)
 
@@ -100,8 +139,8 @@ class TestObjectController(unittest.TestCase):
         self.storage.object_create = Mock(return_value=ret_val)
         resp = req.get_response(self.app)
         self.storage.object_create.assert_called_once_with(
-                'a', 'c', obj_name='o', content_length=0, etag='',
-                metadata={}, content_type='application/octet-stream',
+                'a', 'c', obj_name='o', etag='',
+                metadata={}, mime_type='application/octet-stream',
                 file_or_path=req.environ['wsgi.input'])
         self.assertEqual(resp.status_int, 201)
 
@@ -116,8 +155,10 @@ class TestObjectController(unittest.TestCase):
         req.headers['Etag'] = '"openio"'
         meta = fake_prepare_meta()
         chunks = [{"url": "http://127.0.0.1:7000/AAAA", "pos": "0", "size": 0}]
-        self.storage._content_prepare = Mock(return_value=(meta, chunks))
-        with fakes.set_http_connect(200):
+        self.storage.container.content_prepare = Mock(
+            return_value=(meta, chunks))
+        with patch('oio.api.replication.io.http_connect',
+                   new=fake_http_connect):
             resp = req.get_response(self.app)
         self.assertEqual(resp.status_int, 422)
 
@@ -156,15 +197,17 @@ class TestObjectController(unittest.TestCase):
         req.headers['content-length'] = '6'
         meta = fake_prepare_meta()
         chunks = [{"url": "http://127.0.0.1:7000/AAAA", "pos": "0", "size": 6}]
-        self.storage._content_prepare = Mock(return_value=(meta, chunks))
-        with fakes.set_http_connect(200):
+        self.storage.container.content_prepare = Mock(
+            return_value=(meta, chunks))
+        with patch('oio.api.replication.io.http_connect',
+                   new=fake_http_connect):
             resp = req.get_response(self.app)
         self.assertEqual(resp.status_int, 499)
 
     def test_PUT_chunkreadtimeout_during_transfer_data(self):
         class FakeReader(object):
             def read(self, size):
-                raise exc.ClientReadTimeout()
+                raise oiogreen.SourceReadTimeout()
 
         req = Request.blank('/v1/a/c/o.jpg', method='PUT',
                             body='test body')
@@ -172,10 +215,12 @@ class TestObjectController(unittest.TestCase):
         req.headers['content-length'] = '6'
         meta = fake_prepare_meta()
         chunks = [{"url": "http://127.0.0.1:7000/AAAA", "pos": "0", "size": 6}]
-        self.storage._content_prepare = Mock(return_value=(meta, chunks))
-        with fakes.set_http_connect(200):
+        self.storage.container.content_prepare = Mock(
+            return_value=(meta, chunks))
+        with patch('oio.api.replication.io.http_connect',
+                   new=fake_http_connect):
             resp = req.get_response(self.app)
-        self.assertEqual(resp.status_int, 408)
+            self.assertEqual(resp.status_int, 408)
 
     def test_PUT_timeout_during_transfer_data(self):
         class FakeReader(object):
@@ -188,10 +233,12 @@ class TestObjectController(unittest.TestCase):
         req.headers['content-length'] = '6'
         chunks = [{"url": "http://127.0.0.1:7000/AAAA", "pos": "0", "size": 6}]
         meta = fake_prepare_meta()
-        self.storage._content_prepare = Mock(return_value=(meta, chunks))
-        with fakes.set_http_connect(200):
+        self.storage.container.content_prepare = Mock(
+            return_value=(meta, chunks))
+        with patch('oio.api.replication.io.http_connect',
+                   new=fake_http_connect):
             resp = req.get_response(self.app)
-        self.assertEqual(resp.status_int, 499)
+            self.assertEqual(resp.status_int, 499)
 
     def test_exception_during_transfer_data(self):
         class FakeReader(object):
@@ -205,8 +252,7 @@ class TestObjectController(unittest.TestCase):
         chunks = [{"url": "http://127.0.0.1:7000/AAAA", "pos": "0", "size": 6}]
         meta = fake_prepare_meta()
         self.storage._content_prepare = Mock(return_value=(meta, chunks))
-        with fakes.set_http_connect(200):
-            resp = req.get_response(self.app)
+        resp = req.get_response(self.app)
 
         self.assertEqual(resp.status_int, 500)
 
@@ -216,7 +262,9 @@ class TestObjectController(unittest.TestCase):
         ret_value = ({
             'hash': 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
             'ctime': 0,
-            'length': 1
+            'length': 1,
+            'deleted': False,
+            'version': 42,
             }, fake_stream(1))
         self.storage.object_fetch = Mock(return_value=ret_value)
         resp = req.get_response(self.app)
@@ -228,72 +276,3 @@ class TestObjectController(unittest.TestCase):
         self.storage.object_fetch = Mock(side_effect=exc.NoSuchObject)
         resp = req.get_response(self.app)
         self.assertEqual(resp.status_int, 404)
-
-    def test_POST_as_COPY_simple(self):
-        req = Request.blank('/v1/a/c/o', method='POST')
-        meta = {
-                "hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-                "ctime": 0,
-                "length": 0,
-        }
-        created = (
-                {},
-                0,
-                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-        )
-        self.storage.object_fetch = Mock(return_value=(meta, fake_stream(0)))
-        self.storage.object_create = Mock(return_value=created)
-        resp = req.get_response(self.app)
-        self.assertEqual(resp.status_int, 202)
-        self.assertEqual(req.environ['QUERY_STRING'], '')
-        self.assertTrue('swift.post_as_copy' in req.environ)
-
-    def test_COPY_simple(self):
-        req = Request.blank('/v1/a/c/o', method='COPY',
-                            headers={'Content-Length': 0,
-                                     'Destination': 'c/o-copy'})
-
-        meta = {
-                "hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-                "ctime": 0,
-                "length": 0,
-        }
-
-        created = (
-                {},
-                0,
-                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-        )
-        self.storage.object_fetch = Mock(return_value=(meta, fake_stream(0)))
-        self.storage.object_create = Mock(return_value=created)
-        resp = req.get_response(self.app)
-        self.assertEqual(resp.status_int, 201)
-
-    def test_PUT_log_info(self):
-        req = Request.blank('/v1/a/c/o', method='PUT')
-        req.headers['x-copy-from'] = 'some/where'
-        req.headers['Content-Length'] = 0
-
-        meta = {
-                "hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-                "ctime": 0,
-                "length": 0,
-        }
-        created = (
-                {},
-                0,
-                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-        )
-        self.storage.object_fetch = Mock(return_value=(meta, fake_stream(0)))
-        self.storage.object_create = Mock(return_value=created)
-        resp = req.get_response(self.app)
-        self.assertEqual(resp.status_int, 201)
-        self.assertEqual(
-            req.environ.get('swift.log_info'), ['x-copy-from:some/where'])
-        req = Request.blank('/v1/a/c/o')
-        req.method = 'POST'
-        req.headers['x-copy-from'] = 'else/where'
-
-        resp = req.get_response(self.app)
-        self.assertEqual(resp.status_int, 202)
-        self.assertEqual(req.environ.get('swift.log_info'), None)


### PR DESCRIPTION
Remove some tests which are no more relevant (COPY is handled by a
dedicated middleware, swift.log_info is never set).