### PR TITLE
controllers: Manage error 503

### DIFF
--- a/oioswift/proxy/controllers/account.py
+++ b/oioswift/proxy/controllers/account.py
@@ -31,6 +31,8 @@ from swift.proxy.controllers.base import set_info_cache, clear_info_cache
 
 from oio.common import exceptions
 
+from oioswift.utils import handle_service_busy
+
 
 def get_response_headers(info):
     resp_headers = {
@@ -99,6 +101,7 @@ def account_listing_response(account, req, response_content_type,
 
 class AccountController(SwiftAccountController):
     @public
+    @handle_service_busy
     def GET(self, req):
         """Handler for HTTP GET requests."""
         if len(self.account_name) > constraints.MAX_ACCOUNT_NAME_LENGTH:
@@ -163,6 +166,7 @@ class AccountController(SwiftAccountController):
         return resp
 
     @public
+    @handle_service_busy
     def HEAD(self, req):
         """HTTP HEAD request handler."""
         if len(self.account_name) > constraints.MAX_ACCOUNT_NAME_LENGTH:
@@ -199,6 +203,7 @@ class AccountController(SwiftAccountController):
         return resp
 
     @public
+    @handle_service_busy
     def PUT(self, req):
         """HTTP PUT request handler."""
         if not self.app.allow_account_management:
@@ -238,6 +243,7 @@ class AccountController(SwiftAccountController):
         return resp
 
     @public
+    @handle_service_busy
     def POST(self, req):
         """HTTP POST request handler."""
         if len(self.account_name) > constraints.MAX_ACCOUNT_NAME_LENGTH:
@@ -277,6 +283,7 @@ class AccountController(SwiftAccountController):
         return resp
 
     @public
+    @handle_service_busy
     def DELETE(self, req):
         """HTTP DELETE request handler."""
         if req.query_string:

--- a/oioswift/proxy/controllers/container.py
+++ b/oioswift/proxy/controllers/container.py
@@ -34,7 +34,7 @@ from swift.proxy.controllers.base import clear_info_cache, \
 
 from oio.common import exceptions
 
-from oioswift.utils import get_listing_content_type
+from oioswift.utils import get_listing_content_type, handle_service_busy
 
 
 class ContainerController(SwiftContainerController):
@@ -210,6 +210,7 @@ class ContainerController(SwiftContainerController):
     @public
     @delay_denial
     @cors_validation
+    @handle_service_busy
     def GET(self, req):
         """Handler for HTTP GET requests."""
         return self.GETorHEAD(req)
@@ -217,6 +218,7 @@ class ContainerController(SwiftContainerController):
     @public
     @delay_denial
     @cors_validation
+    @handle_service_busy
     def HEAD(self, req):
         """Handler for HTTP HEAD requests."""
         return self.GETorHEAD(req)
@@ -279,6 +281,7 @@ class ContainerController(SwiftContainerController):
 
     @public
     @cors_validation
+    @handle_service_busy
     def PUT(self, req):
         """HTTP PUT request handler."""
         error_response = \
@@ -323,6 +326,7 @@ class ContainerController(SwiftContainerController):
 
     @public
     @cors_validation
+    @handle_service_busy
     def POST(self, req):
         """HTTP POST request handler."""
         error_response = \
@@ -373,6 +377,7 @@ class ContainerController(SwiftContainerController):
 
     @public
     @cors_validation
+    @handle_service_busy
     def DELETE(self, req):
         """HTTP DELETE request handler."""
         account_partition, accounts, container_count = \

--- a/oioswift/proxy/controllers/obj.py
+++ b/oioswift/proxy/controllers/obj.py
@@ -39,6 +39,8 @@ from oio.common import exceptions
 from oio.common.http import ranges_from_http_header
 from oio.common.green import SourceReadTimeout
 
+from oioswift.utils import handle_service_busy, ServiceBusy
+
 
 class ObjectControllerRouter(object):
     def __getitem__(self, policy):
@@ -82,6 +84,7 @@ class ObjectController(BaseObjectController):
     @public
     @cors_validation
     @delay_denial
+    @handle_service_busy
     def HEAD(self, req):
         """Handle HEAD requests."""
         return self.GETorHEAD(req)
@@ -89,6 +92,7 @@ class ObjectController(BaseObjectController):
     @public
     @cors_validation
     @delay_denial
+    @handle_service_busy
     def GET(self, req):
         """Handle GET requests."""
         return self.GETorHEAD(req)
@@ -198,6 +202,7 @@ class ObjectController(BaseObjectController):
     @public
     @cors_validation
     @delay_denial
+    @handle_service_busy
     def POST(self, req):
         """HTTP POST request handler."""
         container_info = self.container_info(
@@ -239,6 +244,7 @@ class ObjectController(BaseObjectController):
     @public
     @cors_validation
     @delay_denial
+    @handle_service_busy
     def PUT(self, req):
         """HTTP PUT request handler."""
         if req.if_none_match is not None and '*' not in req.if_none_match:
@@ -339,6 +345,8 @@ class ObjectController(BaseObjectController):
             self.app.logger.exception(
                 _('ERROR Exception causing client disconnect'))
             raise HTTPClientDisconnect(request=req)
+        except ServiceBusy:
+            raise
         except Exception:
             self.app.logger.exception(
                 _('ERROR Exception transferring data %s'),
@@ -379,6 +387,7 @@ class ObjectController(BaseObjectController):
     @public
     @cors_validation
     @delay_denial
+    @handle_service_busy
     def DELETE(self, req):
         """HTTP DELETE request handler."""
         container_info = self.container_info(


### PR DESCRIPTION
Catch error 503 to return `HTTPServiceUnavailable` with` Retry-After` in the header.

See [oio-sds#1104](https://github.com/open-io/oio-sds/pull/1104)