### PR TITLE
regexcontainer: add stop_at_first_match option

### DIFF
--- a/conf/default.cfg
+++ b/conf/default.cfg
@@ -89,7 +89,20 @@ use = egg:oioswift#regexcontainer
 # If no pattern matches, an error is returned. You should ensure the last
 # pattern always matches something.
 pattern1 = /(\d+)/(\d+)/(\d+)/
+
+# Match anything up to last forward slash, plus any first two hexadecimal
+# digits in a URL that has a series of 8 (opportunistic sharding)
+pattern8 = ^(.+)/.*?([0-9A-Fa-f]{2})(?=[0-9A-Fa-f]{6})
+
+# "Joker" pattern, match anything up to first forward slash
 pattern9 = ^([^/]+)
+
+# By default, try only the first pattern that the URL matches.
+# When set to false, if a 404 response is to be returned, try successively
+# all other patterns, until a response with any other code is returned.
+# If all responses are 404s, return the first one.
+# Setting this option to false requires openio-sds >= 4.2.
+#stop_at_first_match = true
 
 [filter:autocontainer]
 use = egg:oioswift#autocontainer

--- a/oioswift/common/middleware/autocontainerbase.py
+++ b/oioswift/common/middleware/autocontainerbase.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from functools import partial
 from six.moves.urllib.parse import parse_qs, quote_plus
 from swift.common.swob import HTTPBadRequest
 from swift.common.utils import config_true_value, split_path
@@ -25,7 +26,8 @@ class AutoContainerBase(object):
     BYPASS_HEADER = "X-bypass-autocontainer"
 
     def __init__(self, app, acct,
-                 strip_v1=False, account_first=False, swift3_compat=False):
+                 strip_v1=False, account_first=False, swift3_compat=False,
+                 stop_at_first_match=True):
         self.app = app
         self.account = acct
         self.bypass_header_key = ("HTTP_" +
@@ -34,6 +36,11 @@ class AutoContainerBase(object):
         self.account_first = account_first
         self.swift3_compat = swift3_compat
         self.strip_v1 = strip_v1
+        if (not stop_at_first_match and
+                not hasattr(self.con_builder, 'alternatives')):
+            raise ValueError("Setting 'stop_at_first_match' parameter "
+                             "is not supported with openio-sds < 4.2")
+        self.stop_at_first_match = stop_at_first_match
 
     def should_bypass(self, env):
         """Should we bypass this filter?"""
@@ -41,7 +48,7 @@ class AutoContainerBase(object):
         query = parse_qs(env.get('QUERY_STRING', "")).get(self.BYPASS_QS, [""])
         return config_true_value(header) or config_true_value(query[0])
 
-    def _convert_path(self, path):
+    def _extract_path(self, path):
         account = self.account
         # Remove leading '/' to be consistent with split_path()
         obj = path[1:]
@@ -60,35 +67,121 @@ class AutoContainerBase(object):
             container, tail = split_path('/' + obj, 1, 2, True)
             obj = tail
 
-        if obj is None:
-            return account, container, None
-
-        container = quote_plus(self.con_builder(obj))
         return account, container, obj
 
-    def _convert_special_headers(self, account, env):
-        if 'HTTP_X_COPY_FROM' in env:
-            # HTTP_X_COPY_FROM_ACCOUNT will just pass through
-            if self.account_first:
-                src_path = "/fake_account" + env['HTTP_X_COPY_FROM']
-            else:
-                src_path = env['HTTP_X_COPY_FROM']
-            _, cont, obj = self._convert_path(src_path)
-            if not cont or not obj:
+    def _convert_path(self, path):
+        account, container, obj = self._extract_path(path)
+        if obj is not None:
+            container = quote_plus(self.con_builder(obj))
+        return account, container, obj
+
+    def _alternatives(self, path):
+        account, container, obj = self._extract_path(path)
+        if obj is None:
+            yield account, container, obj
+        elif self.stop_at_first_match:
+            yield account, quote_plus(self.con_builder(obj)), obj
+        else:
+            for alt_container in self.con_builder.alternatives(obj):
+                yield account, quote_plus(alt_container), obj
+        raise StopIteration
+
+    @staticmethod
+    def is_copy(env):
+        """Tell if `env` represents an object copy operation."""
+        return env['REQUEST_METHOD'] == 'PUT' and 'HTTP_X_COPY_FROM' in env
+
+    @staticmethod
+    def _save_response(env, status, headers, exc_info=None):
+        env['last_status'] = status
+        env['last_headers'] = headers
+        env['last_exc_info'] = exc_info
+        if 'first_status' not in env:
+            env['first_status'] = status
+            env['first_headers'] = headers
+            env['first_exc_info'] = exc_info
+
+    def _retry_loop(self, orig_env, start_response, path_to_modify,
+                    env_modifier, alt_checker=None):
+        """
+        :param env_modifier: function copies and modifies the env
+            dictionary, according to the alternative path parts
+        :param alt_checker: function that checks the alternative
+            path parts (may raise an exception)
+        """
+        local_env = {}
+        for alt in self._alternatives(path_to_modify):
+            if alt_checker and not alt_checker(alt):
+                return self.app(orig_env, start_response)
+            env = env_modifier(orig_env, alt)
+            resp = self.app(env, partial(self._save_response, local_env))
+            if not local_env['last_status'].startswith('404'):
+                start_response(local_env['last_status'],
+                               local_env['last_headers'],
+                               local_env['last_exc_info'])
+                return resp
+            if 'first_resp' not in local_env:
+                local_env['first_resp'] = resp
+
+        start_response(local_env['first_status'],
+                       local_env['first_headers'],
+                       local_env['first_exc_info'])
+        return local_env['first_resp']
+
+    def _call_copy(self, env, start_response):
+        """
+        Run the retry loop (copy operations).
+        """
+        account, container, obj = self._convert_path(env.get('PATH_INFO'))
+        if obj is None:
+            # This is probably an account request
+            return self.app(env, start_response)
+        env['PATH_INFO'] = "/v1/%s/%s/%s" % (account, container, obj)
+
+        # HTTP_X_COPY_FROM_ACCOUNT will just pass through
+        if self.account_first:
+            src_path = "/fake_account" + env['HTTP_X_COPY_FROM']
+        else:
+            src_path = env['HTTP_X_COPY_FROM']
+
+        def modify_copy_from(orig_env, alternative):
+            env_ = orig_env.copy()
+            env_['HTTP_X_COPY_FROM'] = "/%s/%s" % (
+                quote_plus(alternative[1]), alternative[2])
+            return env_
+
+        def check_container_obj(alternative):
+            if not alternative[1] or not alternative[2]:
                 raise HTTPBadRequest(body="Malformed copy-source header")
-            env['HTTP_X_COPY_FROM'] = "/%s/%s" % (cont, obj)
+            return True
+
+        return self._retry_loop(
+            env, start_response, src_path,
+            env_modifier=modify_copy_from,
+            alt_checker=check_container_obj)
+
+    def _call(self, env, start_response):
+        """
+        Run the retry loop (regular operations).
+        """
+        def modify_path_info(orig_env, alternative):
+            env_ = orig_env.copy()
+            env_['PATH_INFO'] = "/v1/%s/%s/%s" % alternative
+            return env_
+
+        def check_obj(alternative):
+            return alternative[2] is not None
+
+        return self._retry_loop(
+            env, start_response, env['PATH_INFO'],
+            env_modifier=modify_path_info,
+            alt_checker=check_obj)
 
     def __call__(self, env, start_response):
         if self.should_bypass(env):
             return self.app(env, start_response)
 
-        account, container, obj = self._convert_path(env.get('PATH_INFO'))
-
-        if obj is None:
-            # This is probably an account request
-            return self.app(env, start_response)
-
-        env['PATH_INFO'] = "/v1/%s/%s/%s" % (account, container, obj)
-
-        self._convert_special_headers(account, env)
-        return self.app(env, start_response)
+        if self.is_copy(env):
+            return self._call_copy(env, start_response)
+        else:
+            return self._call(env, start_response)

--- a/oioswift/common/middleware/regexcontainer.py
+++ b/oioswift/common/middleware/regexcontainer.py
@@ -43,6 +43,8 @@ def filter_factory(global_conf, **local_config):
     account_first = config_true_value(local_config.get('account_first'))
     swift3_compat = config_true_value(local_config.get('swift3_compat'))
     strip_v1 = config_true_value(local_config.get('strip_v1'))
+    stop_at_first_match = config_true_value(
+        local_config.get('stop_at_first_match'))
     pattern_dict = {k: v for k, v in local_config.items()
                     if k.startswith("pattern")}
 
@@ -53,5 +55,6 @@ def filter_factory(global_conf, **local_config):
         return RegexContainerMiddleware(
             app, acct, patterns,
             strip_v1=strip_v1, account_first=account_first,
-            swift3_compat=swift3_compat)
+            swift3_compat=swift3_compat,
+            stop_at_first_match=stop_at_first_match)
     return factory


### PR DESCRIPTION
Now, the regexcontainer middleware is able to loop on patterns if
the one that matches triggers a 404 error.