### PR TITLE
[WIP] Controller fastcopy

### DIFF
--- a/oioswift/common/middleware/container_hierarchy.py
+++ b/oioswift/common/middleware/container_hierarchy.py
@@ -179,6 +179,10 @@ class ContainerHierarchyMiddleware(AutoContainerBase):
         if req.method == 'TEST':
             return self.app(env, start_response)
 
+        # TODO: should test if container name ends with ?
+        if '%2Bsegments/' in req.path:
+            return self.app(env, start_response)
+
         account, container, obj = self._extract_path(req.path_info)
         env2 = env.copy()
         qs = parse_qs(req.query_string or '')

--- a/oioswift/common/middleware/container_hierarchy.py
+++ b/oioswift/common/middleware/container_hierarchy.py
@@ -180,7 +180,7 @@ class ContainerHierarchyMiddleware(AutoContainerBase):
             return self.app(env, start_response)
 
         # TODO: should test if container name ends with ?
-        if '%2Bsegments/' in req.path:
+        if '%2Bsegments' in req.path:
             return self.app(env, start_response)
 
         account, container, obj = self._extract_path(req.path_info)

--- a/oioswift/common/middleware/copy.py
+++ b/oioswift/common/middleware/copy.py
@@ -1,0 +1,53 @@
+
+from swift.common.utils import get_logger
+from swift.common.swob import Request
+
+class ServerSideCopyMiddleware(object):
+    def __init__(self, app, conf):
+        self.app = app
+        self.logger = get_logger(conf, log_route="copy")
+
+    def __call__(self, env, start_response):
+        req = Request(env)
+        try:
+            (version, account, container, obj) = req.split_path(4, 4, True)
+        except ValueError:
+            # If obj component is not present in req, do not proceed further.
+            return self.app(env, start_response)
+
+        self.account_name = account
+        self.container_name = container
+        self.object_name = obj
+
+        """ TODO explore various case shown below !
+        try:
+            # In some cases, save off original request method since it gets
+            # mutated into PUT during handling. This way logging can display
+            # the method the client actually sent.
+            if req.method == 'PUT' and req.headers.get('X-Copy-From'):
+                return self.handle_PUT(req, start_response)
+            elif req.method == 'COPY':
+                req.environ['swift.orig_req_method'] = req.method
+                return self.handle_COPY(req, start_response)
+            elif req.method == 'POST' and self.object_post_as_copy:
+                req.environ['swift.orig_req_method'] = req.method
+                return self.handle_object_post_as_copy(req, start_response)
+            elif req.method == 'OPTIONS':
+                # Does not interfere with OPTIONS response from
+                # (account,container) servers and /info response.
+                return self.handle_OPTIONS(req, start_response)
+
+        except HTTPException as e:
+            return e(req.environ, start_response)
+        """
+
+        return self.app(env, start_response)
+
+def filter_factory(global_conf, **local_conf):
+    conf = global_conf.copy()
+    conf.update(local_conf)
+
+    def copy_filter(app):
+        return ServerSideCopyMiddleware(app, conf)
+
+    return copy_filter

--- a/oioswift/proxy/controllers/obj.py
+++ b/oioswift/proxy/controllers/obj.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import mimetypes
 import time
 import math
@@ -302,6 +303,9 @@ class ObjectController(BaseObjectController):
         if error_response:
             return error_response
 
+        if req.headers.get('X-Copy-From'):
+            return self._link_object(req)
+
         self._update_x_timestamp(req)
 
         data_source = req.environ['wsgi.input']
@@ -325,6 +329,64 @@ class ObjectController(BaseObjectController):
                 policy = name
 
         return policy
+
+    def _link_object(self, req):
+        _, container, obj = req.headers['X-Copy-From'].split('/', 2)
+
+        self.app.logger.info("LINK (%s,%s,%s) TO (%s,%s,%s)",
+            self.account_name, self.container_name, self.object_name,
+            self.account_name, container, obj)
+        storage = self.app.storage
+
+        if req.headers.get('Range'):
+            ranges = ranges_from_http_header(req.headers.get('Range'))
+            if len(ranges) != 1:
+                # TODO use proper SwiftException
+                raise Exception("Invalid number of ranges")
+            ranges = ranges[0]
+        else:
+            ranges = None
+
+        SLO = 'x-static-large-object'
+        SLO_SIZE = 'x-object-sysmeta-slo-size'
+
+        props = storage.object_get_properties(self.account_name, container, obj)['properties']
+
+        if props.get(SLO, None):
+            # TODO: abort if no range is specified ?
+            self.app.logger.debug("SLO object detected")
+
+            # retrieve manifest
+            _, data = storage.object_fetch(self.account_name, container, obj)
+            manifest = json.loads("".join(data))
+            part = None
+            offset = 0
+            # found proper part to copy
+            for entry in manifest:
+                if ranges[0] == offset and ranges[1] + 1 == offset + entry['bytes']:
+                    part = entry
+                    break
+                offset += entry['bytes']
+            else:
+                # TODO use proper SwiftException
+                raise Exception("Invalid state")
+
+            _, container, obj = part['name'].split('/', 2)
+            self.app.logger.info("LINK SLO (%s,%s,%s) TO (%s,%s,%s)",
+                self.account_name, self.container_name, self.object_name,
+                self.account_name, container, obj)
+            ret = storage.object_fastcopy(self.account_name, container, obj,
+                                    self.account_name, self.container_name, self.object_name)
+            checksum = part['hash']
+        else:
+            # TODO: abort if a range is specified
+            ret = storage.object_fastcopy(self.account_name, container, obj,
+                                    self.account_name, self.container_name, self.object_name)
+            checksum = props['hash']
+
+        resp = HTTPCreated(request=req, etag=checksum)
+        return resp
+
 
     def _store_object(self, req, data_source, headers):
         content_type = req.headers.get('content-type', 'octet/stream')

--- a/oioswift/proxy/controllers/obj.py
+++ b/oioswift/proxy/controllers/obj.py
@@ -350,11 +350,10 @@ class ObjectController(BaseObjectController):
         SLO = 'x-static-large-object'
         SLO_SIZE = 'x-object-sysmeta-slo-size'
 
-        props = storage.object_get_properties(self.account_name, container, obj)['properties']
-
-        if props.get(SLO, None):
+        props = storage.object_get_properties(self.account_name, container, obj)
+        if props['properties'].get(SLO, None):
             # TODO: abort if no range is specified ?
-            self.app.logger.debug("SLO object detected")
+            self.app.logger.debug("LINK, original object is a SLO")
 
             # retrieve manifest
             _, data = storage.object_fetch(self.account_name, container, obj)
@@ -383,6 +382,7 @@ class ObjectController(BaseObjectController):
             ret = storage.object_fastcopy(self.account_name, container, obj,
                                     self.account_name, self.container_name, self.object_name)
             checksum = props['hash']
+
 
         resp = HTTPCreated(request=req, etag=checksum)
         return resp

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
             'regexcontainer=oioswift.common.middleware.regexcontainer:filter_factory',
             'versioned_writes=oioswift.common.middleware.versioned_writes:filter_factory',
             'container_hierarchy=oioswift.common.middleware.container_hierarchy:filter_factory',
+            'copy=oioswift.common.middleware.copy:filter_factory',
         ],
     },
     install_requires=['swift>=2.13.0', 'oio>=4.1.0']


### PR DESCRIPTION
Fix MPU with controller_hierarchy (it should be rework as all segments of SLO will be stored on same bucket !)
Add support for fast copy on sds side, with severals limitations:
- support of COPY with a RANGE on single object is not supported
- COPY of a SLO object is only supported to recreate SLO (no conversion from MPU to a single object) and RANGE must be aligned on a part

[ ] error management (refactor with PUT method ?)
[ ] manage various cases present in original copy middleware
[ ] test overwrite of content previously created by a hardlink (with or without MPU)
[ ] check ETAG