### PR TITLE
container_hierarchy: fix recursive listing without final /

### DIFF
--- a/oioswift/common/middleware/container_hierarchy.py
+++ b/oioswift/common/middleware/container_hierarchy.py
@@ -288,7 +288,7 @@ class ContainerHierarchyMiddleware(AutoContainerBase):
             all_objs = [x for x in self._list_objects(
                         env, account,
                         tuple(container.split(self.ENCODED_DELIMITER)),
-                        header_cb)]
+                        header_cb, prefix=obj or '')]
             body = json.dumps(all_objs)
             oheaders['X-Container-Object-Count'] = len(all_objs)
             # FIXME: aggregate X-Container-Bytes-Used


### PR DESCRIPTION
Fix issue with recursive listing, the final obj (without /) was not used as prefix

$ aws s3 ls --recursive s3://ooo/v1/v2/v6/
2018-03-22 11:13:57       3164 v1/v2/v6/passwd

$ aws s3 ls --recursive s3://ooo/v1/v2/v6
2018-03-22 11:13:45       3164 v1/v2/v3/passwd
2018-03-22 11:13:51       3164 v1/v2/v4/passwd
2018-03-22 11:13:54       3164 v1/v2/v5/passwd
2018-03-22 11:13:57       3164 v1/v2/v6/passwd
2018-03-22 11:14:00       3164 v1/v2/v7/passwd

Only v1/v2/ was used !