### PR TITLE
fastcopy: fix SLO as source and plain objet as target

### DIFF
--- a/oioswift/proxy/controllers/obj.py
+++ b/oioswift/proxy/controllers/obj.py
@@ -335,6 +335,7 @@ class ObjectController(BaseObjectController):
     def _link_object(self, req):
         _, container, obj = req.headers['Oio-Copy-From'].split('/', 2)
 
+        # FIXME(FVE): load account name from X-Copy-From-Account
         self.app.logger.info("LINK (%s,%s,%s) TO (%s,%s,%s)",
                              self.account_name, self.container_name,
                              self.object_name,

--- a/oioswift/proxy/controllers/obj.py
+++ b/oioswift/proxy/controllers/obj.py
@@ -342,7 +342,7 @@ class ObjectController(BaseObjectController):
         storage = self.app.storage
 
         if req.headers.get('Range'):
-            raise Exception("NOT SUPPORTED AT THIS TIME")
+            raise Exception("Fast Copy with Range is unsupported")
 
             ranges = ranges_from_http_header(req.headers.get('Range'))
             if len(ranges) != 1:
@@ -356,7 +356,7 @@ class ObjectController(BaseObjectController):
         props = storage.object_get_properties(self.account_name, container,
                                               obj)
         if props['properties'].get(SLO, None):
-            raise Exception("NOT SUPPORTED AT THIS TIME")
+            raise Exception("Fast Copy with SLO is unsupported")
 
             if ranges is None:
                 raise HTTPInternalServerError(request=req,


### PR DESCRIPTION
To reproduce it:

$ dd if=/dev/zero of=bigfile bs=1M count=20M
$ aws s3 cp bigfile s3://bucket
$ aws s3api copy-object --bucket bucket --copy-source bucket/bigfile --key plain_object

Error message to impossible case in proxy/controller/obj.py has also
been updated to be more explicit.