### PR TITLE
Autocontainer: fix MPU complete

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
   - sudo apt-add-repository "deb http://archive.ubuntu.com/ubuntu trusty-backports main restricted universe multiverse"
   - sudo apt-add-repository "deb http://mirror.openio.io/pub/repo/openio/sds/17.04/ubuntu/trusty ./"
   - sudo apt-get update -qq
-  - sudo apt-get install -y --force-yes python-virtualenv liberasurecode-dev libssl-dev libattr1-dev libleveldb1 libleveldb-dev
+  - sudo apt-get install -y --force-yes python-virtualenv liberasurecode-dev libssl-dev libattr1-dev libleveldb1 libleveldb-dev libzookeeper-mt-dev
   - virtualenv $HOME/venv
   - source $HOME/venv/bin/activate
   - pip install --upgrade pip setuptools virtualenv tox flake8

--- a/oioswift/common/middleware/autocontainerbase.py
+++ b/oioswift/common/middleware/autocontainerbase.py
@@ -114,7 +114,7 @@ class AutoContainerBase(object):
             path parts (may raise an exception)
         """
         local_env = {}
-        query = parse_qs(orig_env['QUERY_STRING'], True)
+        query = parse_qs(orig_env.get('QUERY_STRING', ''), True)
         account, container, obj = self._extract_path(path_to_modify)
         is_container_req = container is not None and obj is None
         if is_container_req and 'prefix' in query:

--- a/oioswift/common/middleware/autocontainerbase.py
+++ b/oioswift/common/middleware/autocontainerbase.py
@@ -78,13 +78,16 @@ class AutoContainerBase(object):
         return account, container, obj
 
     def _alternatives(self, account, container, obj):
+        # put S3 parts in dedicated container
+        suffix = ("+segments" if container and container.endswith('+segments')
+                  else "")
         if obj is None:
             yield account, container, obj
         elif self.stop_at_first_match:
-            yield account, quote_plus(self.con_builder(obj)), obj
+            yield account, quote_plus(self.con_builder(obj)) + suffix, obj
         else:
             for alt_container in self.con_builder.alternatives(obj):
-                yield account, quote_plus(alt_container), obj
+                yield account, quote_plus(alt_container) + suffix, obj
         raise StopIteration
 
     @staticmethod


### PR DESCRIPTION
This commit fix the MPU fonctionality:
- when a MPU is complete, it check every part
The autocontainer now fix listing with prefix (prefix itself is not
updated but prefix path is used when resolving container name)
- When manifest is send by swift3, autocontainerbase got an iterator
instead of a proper status, headers, ... We force call to reiterate
to resolve it.