### PR TITLE
Expose parameter to control container autocreate

### DIFF
--- a/conf/default.cfg
+++ b/conf/default.cfg
@@ -76,6 +76,10 @@ use = egg:oioswift#main
 allow_account_management = true
 account_autocreate = true
 
+# Manage if container should be created if nonexisting
+# It must be true if hashedcontainer, regexcontainer, autocontainer or container_hierarchy middleware is used
+sds_autocreate = true
+
 [filter:hashedcontainer]
 use = egg:oioswift#hashedcontainer
 

--- a/conf/default.cfg
+++ b/conf/default.cfg
@@ -76,9 +76,11 @@ use = egg:oioswift#main
 allow_account_management = true
 account_autocreate = true
 
-# Manage if container should be created if nonexisting
-# It must be true if hashedcontainer, regexcontainer, autocontainer or container_hierarchy middleware is used
-sds_autocreate = true
+# Enable or disable container autocreation. When disabled, trying to create
+# an object in a container that does not exist will trigger an error.
+# This parameter must be true if any of hashedcontainer, regexcontainer,
+# autocontainer or container_hierarchy middleware is used.
+#sds_autocreate = true
 
 [filter:hashedcontainer]
 use = egg:oioswift#hashedcontainer

--- a/oioswift/proxy/controllers/obj.py
+++ b/oioswift/proxy/controllers/obj.py
@@ -498,6 +498,8 @@ class ObjectController(BaseObjectController):
             return HTTPUnprocessableEntity(request=req)
         except (exceptions.ServiceBusy, exceptions.OioTimeout):
             raise
+        # TODO(FVE): exceptions.NotFound is never raised from oio
+        # Remove when dependency is oio>=4.2.0
         except (exceptions.NoSuchContainer, exceptions.NotFound):
             raise HTTPNotFound(request=req)
         except exceptions.ClientException as err:

--- a/oioswift/proxy/controllers/obj.py
+++ b/oioswift/proxy/controllers/obj.py
@@ -427,6 +427,8 @@ class ObjectController(BaseObjectController):
             return HTTPUnprocessableEntity(request=req)
         except (exceptions.ServiceBusy, exceptions.OioTimeout):
             raise
+        except (exceptions.NoSuchContainer, exceptions.NotFound):
+            raise HTTPNotFound(request=req)
         except exceptions.ClientException as err:
             # 481 = CODE_POLICY_NOT_SATISFIABLE
             if err.status == 481:
@@ -496,6 +498,8 @@ class ObjectController(BaseObjectController):
             return HTTPUnprocessableEntity(request=req)
         except (exceptions.ServiceBusy, exceptions.OioTimeout):
             raise
+        except (exceptions.NoSuchContainer, exceptions.NotFound):
+            raise HTTPNotFound(request=req)
         except exceptions.ClientException as err:
             # 481 = CODE_POLICY_NOT_SATISFIABLE
             if err.status == 481:

--- a/oioswift/server.py
+++ b/oioswift/server.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016 OpenIO SAS
+# Copyright (c) 2016-2018 OpenIO SAS
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -85,8 +85,8 @@ class Application(SwiftApplication):
         if 'autocreate' in sds_conf and not (
                 hasattr(ObjectStorageApi, 'EXTRA_KEYWORDS') or
                 'autocreate' in ObjectStorageApi.EXTRA_KEYWORDS):
-            logger.error('autocreate parameter is not available with current '
-                         'OpenIO SDS')
+            logger.warn("'autocreate' parameter is ignored by current version"
+                        " of OpenIO SDS. Please update to oio>=4.1.23.")
         else:
             sds_conf['autocreate'] = config_true_value(
                 sds_conf.get('autocreate', 'true'))

--- a/oioswift/server.py
+++ b/oioswift/server.py
@@ -21,6 +21,7 @@ from oioswift.proxy.controllers.account import AccountController
 from oioswift.proxy.controllers.obj import ObjectControllerRouter
 from oio import ObjectStorageApi
 from swift.proxy.server import Application as SwiftApplication
+from swift.common.utils import config_true_value
 import swift.common.utils
 import swift.proxy.server
 
@@ -80,6 +81,16 @@ class Application(SwiftApplication):
         sds_conf.pop('namespace')  # removed to avoid unpacking conflict
         # Loaded by ObjectStorageApi if None
         sds_proxy_url = sds_conf.pop('proxy_url', None)
+        # Fix boolean parameter
+        if 'autocreate' in sds_conf and not (
+                hasattr(ObjectStorageApi, 'EXTRA_KEYWORDS') or
+                'autocreate' in ObjectStorageApi.EXTRA_KEYWORDS):
+            logger.error('autocreate parameter is not available with current '
+                         'OpenIO SDS')
+        else:
+            sds_conf['autocreate'] = config_true_value(
+                sds_conf.get('autocreate', 'true'))
+
         self.storage = storage or \
             ObjectStorageApi(sds_namespace, endpoint=sds_proxy_url, **sds_conf)
 


### PR DESCRIPTION
It requires an updated version of OIO-SDS that exposes this parameter,
otherwise parameter will be ignored with a warning.