### PR TITLE
Fix SLO overwrite

### DIFF
--- a/oioswift/common/middleware/copy.py
+++ b/oioswift/common/middleware/copy.py
@@ -75,7 +75,7 @@ class OioServerSideCopyMiddleware(ServerSideCopyMiddleware):
             obj_inf = get_object_info(req.environ, self.app,
                                       path=src_path,
                                       swift_source='SSC')
-            is_slo = obj_inf.get('sysmeta', {}).get('slo-size', False)
+            is_slo = 'X-Static-Large-Object' in obj_inf.get('sysmeta', {})
             if is_slo:
                 self.logger.debug(
                     "COPY: fast copy not available (reason=source is a SLO)")

--- a/oioswift/proxy/controllers/obj.py
+++ b/oioswift/proxy/controllers/obj.py
@@ -30,8 +30,9 @@ from swift.common.swob import HTTPAccepted, HTTPBadRequest, HTTPNotFound, \
     HTTPUnprocessableEntity, HTTPClientDisconnect, HTTPCreated, \
     HTTPNoContent, Response, HTTPInternalServerError, multi_range_iterator
 from swift.common.request_helpers import is_sys_or_user_meta
+from swift.common.wsgi import make_subrequest
 from swift.proxy.controllers.base import set_object_info_cache, \
-        delay_denial, cors_validation
+        delay_denial, cors_validation, get_object_info
 from swift.proxy.controllers.obj import check_content_type
 
 from swift.proxy.controllers.obj import BaseObjectController as \
@@ -289,6 +290,19 @@ class ObjectController(BaseObjectController):
         resp = HTTPAccepted(request=req)
         return resp
 
+    def _delete_slo_parts(self, req, manifest):
+        """Delete parts of an obsolete SLO."""
+        # We cannot use bulk-delete here,
+        # because we are at the end of the pipeline, after 'bulk'.
+        for part in manifest:
+            path = '/'.join(('', 'v1', self.account_name)) + part['name']
+            try:
+                del_req = make_subrequest(req.environ, 'DELETE', path=path)
+                del_req.get_response(self.app)
+            except Exception as exc:
+                self.app.logger.warn('Failed to delete SLO part %s: %s',
+                                     path, exc)
+
     @public
     @cors_validation
     @delay_denial
@@ -310,6 +324,25 @@ class ObjectController(BaseObjectController):
             if aresp:
                 return aresp
 
+        old_slo_manifest = None
+        # If versioning is disabled, we must check if the object exists.
+        # If it's a SLO, we will have to delete the parts if the current
+        # operation is a success.
+        if not container_info['sysmeta'].get('versions-location', None):
+            try:
+                dest_info = get_object_info(req.environ, self.app)
+                if 'slo-size' in dest_info['sysmeta']:
+                    manifest_env = req.environ.copy()
+                    manifest_env['QUERY_STRING'] = 'multipart-manifest=get'
+                    manifest_req = make_subrequest(manifest_env, 'GET')
+                    manifest_resp = manifest_req.get_response(self.app)
+                    old_slo_manifest = json.loads(manifest_resp.body)
+            except Exception as exc:
+                self.app.logger.warn(('Failed to check existence of %s. If '
+                                      'overwriting a SLO, old parts may '
+                                      'remain. Error was: %s') %
+                                     (req.path, exc))
+
         self._update_content_type(req)
 
         # check constraints on object name and request headers
@@ -330,6 +363,11 @@ class ObjectController(BaseObjectController):
         headers = self._prepare_headers(req)
         with closing_if_possible(data_source):
             resp = self._store_object(req, data_source, headers)
+        if old_slo_manifest and resp.is_success:
+            self.app.logger.debug(
+                'Previous object %s was a SLO, deleting parts',
+                req.path)
+            self._delete_slo_parts(req, old_slo_manifest)
         return resp
 
     def _prepare_headers(self, req):


### PR DESCRIPTION
When overwriting a Static Large Object, we have to delete the old parts from the segment container, or they become orphans.