### PR TITLE
[WIP] add a special route to use objgraph

### DIFF
--- a/oioswift/common/middleware/objdump.py
+++ b/oioswift/common/middleware/objdump.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2010-2012 OpenStack Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import objgraph
+
+from swift.common.swob import Request, Response
+
+
+class ObjDumpMiddleware(object):
+    """
+    Healthcheck middleware used for monitoring.
+
+    If the path is /objdump, it will respond 200 with "OK" as the body.
+
+    If the optional config parameter "disable_path" is set, and a file is
+    present at that path, it will respond 503 with "DISABLED BY FILE" as the
+    body.
+    """
+
+    def __init__(self, app, conf):
+        self.app = app
+        self.disable_path = conf.get('disable_path', '')
+
+    def GET(self, req):
+        """Returns a 200 response with "OK" in the body."""
+        stat = {
+            'most': objgraph.most_common_types(limit=20, shortnames=False),
+        }
+        ret = []
+        for x in objgraph.get_leaking_objects():
+            ret.append([str(x), str(type(x))])
+        stat['leak'] = ret
+        data = json.dumps(stat)
+        return Response(request=req, body=data, content_type="application/json")
+
+    def __call__(self, env, start_response):
+        req = Request(env)
+        if req.path == '/objdump':
+            return self.GET(req)(env, start_response)
+        return self.app(env, start_response)
+
+
+def filter_factory(global_conf, **local_conf):
+    conf = global_conf.copy()
+    conf.update(local_conf)
+
+    def objdump_filter(app):
+        return ObjDumpMiddleware(app, conf)
+    return objdump_filter

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
             'container_hierarchy=oioswift.common.middleware.container_hierarchy:filter_factory',
             'copy=oioswift.common.middleware.copy:filter_factory',
             'verb_acl=oioswift.common.middleware.verb_acl:filter_factory',
+            'objdump=oioswift.common.middleware.objdump:filter_factory',
             'tempauth=oioswift.common.middleware.tempauth:filter_factory',
         ],
     },


### PR DESCRIPTION
To enable this middleware, just add objdump just after catch_errors on
pipeline and add below configuration:

```
[filter:objdump]
use = egg:oioswift#objdump
```