### PR TITLE
Delete parts when overwriting a SLO

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,4 @@
+coverage:
+  range: 60..100
+  round: up
+  precision: 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,13 @@ addons:
 
 env:
   matrix:
-    - TEST_SUITE=encryption
-    - TEST_SUITE=ns-wide-versioning
     - TEST_SUITE=s3
-    - TEST_SUITE=unit
-    - TEST_SUITE=encryption SWIFT_BRANCH=stable/pike
-    - TEST_SUITE=ns-wide-versioning SWIFT_BRANCH=stable/pike
     - TEST_SUITE=s3 SWIFT_BRANCH=stable/pike
+    - TEST_SUITE=encryption
+    - TEST_SUITE=encryption SWIFT_BRANCH=stable/pike
+    - TEST_SUITE=ns-wide-versioning
+    - TEST_SUITE=ns-wide-versioning SWIFT_BRANCH=stable/pike
+    - TEST_SUITE=unit
     - TEST_SUITE=unit SWIFT_BRANCH=stable/pike
 
 before_install:
@@ -42,5 +42,4 @@ script:
   - ./tests/run_tests.sh "$TEST_SUITE"
 
 after_success:
-  - bash <(curl -s https://codecov.io/bash) -f cmake_coverage.output
-  - codecov
+  - codecov -X gcov

--- a/conf/default.cfg
+++ b/conf/default.cfg
@@ -85,6 +85,13 @@ account_autocreate = true
 # autocontainer or container_hierarchy middleware is used.
 #sds_autocreate = true
 
+# When a static large object manifest is overwritten, swift's default behavior
+# is to keep the parts, in case another manifest references them. It is the
+# container owner's responsability to delete them.
+# oioswift changes this behavior and deletes the parts by default.
+# To re-establish the default behavior, toggle this setting to false.
+#delete_slo_parts=true
+
 [filter:hashedcontainer]
 use = egg:oioswift#hashedcontainer
 

--- a/oioswift/server.py
+++ b/oioswift/server.py
@@ -95,6 +95,8 @@ class Application(SwiftApplication):
 
         self.storage = storage or \
             ObjectStorageApi(sds_namespace, endpoint=sds_proxy_url, **sds_conf)
+        self.delete_slo_parts = \
+            config_true_value(conf.get('delete_slo_parts', True))
 
 
 def app_factory(global_conf, **local_conf):

--- a/tests/functional/run-ns-wide-versioning-tests.sh
+++ b/tests/functional/run-ns-wide-versioning-tests.sh
@@ -22,7 +22,7 @@ install_deps
 compile_sds
 run_sds
 
-coverage run -a runserver.py conf/hashed-containers.cfg -v &
+coverage run -p runserver.py conf/hashed-containers.cfg -v &
 sleep 1
 PID=$(jobs -p)
 

--- a/tests/functional/run-s3-tests.sh
+++ b/tests/functional/run-s3-tests.sh
@@ -15,7 +15,7 @@ run_functional_test s3-container-hierarchy.cfg s3_container_hierarchy_v2.sh
 run_functional_test s3-fastcopy.cfg s3-acl-metadata.sh
 # Run all suites in the same environment.
 # They do not share buckets so this should be OK.
-run_functional_test s3-default.cfg s3-acl-metadata.sh s3-versioning.sh s3-tagging.sh
+run_functional_test s3-default.cfg s3-acl-metadata.sh s3-versioning.sh s3-tagging.sh s3-multipart.sh
 
 # TODO(FVE): gridinit_cmd stop
 exit $RET

--- a/tests/functional/s3-multipart.sh
+++ b/tests/functional/s3-multipart.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+export OIO_NS="${1:-OPENIO}"
+export OIO_ACCOUNT="${2:-AUTH_demo}"
+
+AWS="aws --endpoint-url http://localhost:5000 --no-verify-ssl"
+BUCKET="bucket-$RANDOM"
+
+set -e
+
+SMALL_FILE="/etc/resolv.conf"
+MULTI_FILE=$(mktemp -t multipart_XXXXXX.dat)
+dd if=/dev/zero of="${MULTI_FILE}" count=21 bs=1M
+
+echo "Creating bucket ${BUCKET}"
+${AWS} s3 mb "s3://$BUCKET"
+
+echo
+echo "Testing the deletion of parts when a multipart object is overwritten"
+echo "--------------------------------------------------------------------"
+echo
+echo "Uploading a multipart object in bucket ${BUCKET}"
+${AWS} s3 cp "$MULTI_FILE" "s3://$BUCKET/obj"
+
+echo "Counting segments with openio CLI"
+SEG_COUNT=$(openio object list ${BUCKET}+segments -f value | wc -l)
+
+dd if=/dev/zero of="${MULTI_FILE}" count=1 bs=1M oflag=append conv=notrunc
+echo "Overwriting with a bigger object"
+${AWS} s3 cp "$MULTI_FILE" "s3://$BUCKET/obj"
+
+echo "Counting segments with openio CLI (should be the same)"
+SEG_COUNT2=$(openio object list ${BUCKET}+segments -f value | wc -l)
+[ "$SEG_COUNT" -eq "$SEG_COUNT2" ]
+
+echo "Overwriting with a small object (not multipart)"
+${AWS} s3 cp "$SMALL_FILE" "s3://$BUCKET/obj"
+
+echo "Counting segments with openio CLI (should be zero)"
+SEG_COUNT3=$(openio object list ${BUCKET}+segments -f value | wc -l)
+[ "$SEG_COUNT3" -eq "0" ]
+
+echo
+echo "Cleanup"
+echo "-------"
+${AWS} s3 rm "s3://$BUCKET/obj"
+${AWS} s3 rb "s3://$BUCKET"
+rm "$MULTI_FILE"

--- a/tests/unit/controllers/test_obj.py
+++ b/tests/unit/controllers/test_obj.py
@@ -256,12 +256,13 @@ class TestObjectController(unittest.TestCase):
         req = Request.blank('/v1/a/c/o', method='PUT')
         req.headers['if-none-match'] = '1111'
         req.headers['content-length'] = '0'
-        ret_val = {'hash': '0000'}
+        ret_val = {'hash': '0000', 'version': '554086800000000',
+                   'ctime': 554086800, 'length': 0, 'deleted': 'false'}
         self.storage.object_show = Mock(return_value=ret_val)
         ret_val2 = ({}, 0, '')
         self.app.storage.object_create = Mock(return_value=ret_val2)
         resp = req.get_response(self.app)
-        self.storage.object_show.assert_called_once()
+        self.storage.object_show.assert_called()
         self.storage.object_create.assert_called_once()
         self.assertEqual(201, resp.status_int)
 

--- a/tests/unit/run_extra_unit_tests.sh
+++ b/tests/unit/run_extra_unit_tests.sh
@@ -3,5 +3,5 @@
 
 set -e
 
-coverage run --source=oioswift,tests -a $(which nosetests) -v --with-timer \
+coverage run --source=oioswift,tests -p $(which nosetests) -v --with-timer \
     tests/unit/common/middleware/test_hashedcontainer.py  # requires liboiocore.so

--- a/tests/unit/run_unit_tests.sh
+++ b/tests/unit/run_unit_tests.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-coverage run --source=oioswift,tests -a $(which nosetests) -v --with-timer \
+coverage run --source=oioswift,tests -p $(which nosetests) -v --with-timer \
     tests/unit/controllers \
     tests/unit/common/middleware/crypto \
     tests/unit/common/middleware/test_copy.py:TestOioServerSideCopyMiddleware \


### PR DESCRIPTION
When a static large object manifest is overwritten, swift's default behavior is to keep the parts, in case another manifest references them. It is the container owner's responsability to delete them. oioswift changes this behavior and deletes the parts by default. To re-establish the default behavior, toggle `delete_slo_parts` to false.