### PR TITLE
versioned_writes: discard object prefixes from listings

### DIFF
--- a/oioswift/common/middleware/versioned_writes.py
+++ b/oioswift/common/middleware/versioned_writes.py
@@ -97,15 +97,21 @@ class OioVersionedWritesContext(vw.VersionedWritesContext):
 
             # Discard the latest version of each object, because it is
             # not supposed to appear in the versioning container.
+            # Also discard object prefixes, which are computed
+            # from the "main" container.
             latest = dict()
             for obj in versioned_objects:
+                if 'subdir' in obj:
+                    continue
                 ver = int(obj.get('version', '0'))
                 if ver > latest.get(obj['name'], 0):
                     latest[obj['name']] = ver
-            versioned_objects = [obj for obj in versioned_objects
-                                 if int(obj.get('version', '0')) !=
-                                 latest[obj['name']] or
-                                 is_deleted(obj)]
+            versioned_objects = [
+                obj for obj in versioned_objects
+                if 'subdir' not in obj
+                and (int(obj.get('version', '0')) != latest[obj['name']]
+                     or is_deleted(obj))
+            ]
 
             for obj in versioned_objects:
                 obj['name'] = swift3_versioned_object_name(

--- a/tests/unit/run_extra_unit_tests.sh
+++ b/tests/unit/run_extra_unit_tests.sh
@@ -3,5 +3,6 @@
 
 set -e
 
-coverage run --source=oioswift,tests -p $(which nosetests) -v --with-timer \
+coverage run --source=oioswift,tests -p $(which nosetests) -v \
+    --with-timer --timer-ok=100ms --timer-warning=1s \
     tests/unit/common/middleware/test_hashedcontainer.py  # requires liboiocore.so

--- a/tests/unit/run_unit_tests.sh
+++ b/tests/unit/run_unit_tests.sh
@@ -2,7 +2,8 @@
 
 set -e
 
-coverage run --source=oioswift,tests -p $(which nosetests) -v --with-timer \
+coverage run --source=oioswift,tests -p $(which nosetests) -v \
+    --with-timer --timer-ok=100ms --timer-warning=1s \
     tests/unit/controllers \
     tests/unit/common/middleware/crypto \
     tests/unit/common/middleware/test_copy.py:TestOioServerSideCopyMiddleware \


### PR DESCRIPTION
When returning object versions, and the request specifies a delimiter, do not return object prefixes.

The upper level usually sends two requests: one for the latest version of each object, one for all previous versions of all objects. Now only the first will return object prefixes.

Jira: OS-211