### PR TITLE
CH: allow listing containers with space

### DIFF
--- a/oioswift/common/middleware/container_hierarchy.py
+++ b/oioswift/common/middleware/container_hierarchy.py
@@ -16,7 +16,7 @@
 import json
 import importlib
 from paste.deploy import loadwsgi
-from six.moves.urllib.parse import parse_qs, quote_plus
+from six.moves.urllib.parse import parse_qs, quote
 from swift.common.swob import Request
 from swift.common.utils import config_true_value, \
     closing_if_possible, get_logger
@@ -359,7 +359,7 @@ class ContainerHierarchyMiddleware(AutoContainerBase):
         """
         returns items
         """
-        sub_path = quote_plus(self.DELIMITER.join(
+        sub_path = quote(self.DELIMITER.join(
             ('', 'v1', account, self.ENCODED_DELIMITER.join(ct_parts))))
 
         LOG.debug("%s: listing objects from '%s' "

--- a/tests/functional/s3_container_hierarchy_v2.sh
+++ b/tests/functional/s3_container_hierarchy_v2.sh
@@ -42,6 +42,19 @@ echo ${OUT} | grep root
 echo ${OUT} | grep dir1/dir2/object
 
 
+# LISTING WITH SPACE
+
+${AWS} s3api put-object --bucket ${BUCKET} --key "directory 1/directory 2/object" --body /etc/passwd
+${AWS} s3api put-object --bucket ${BUCKET} --key "directory 1/directory 2/other one" --body /etc/passwd
+
+OUT=$( ${AWS} s3api list-objects --bucket ${BUCKET} )
+echo ${OUT} | grep object
+echo ${OUT} | grep "other one"
+
+OUT=$( ${AWS} s3 ls "s3://${BUCKET}/directory 1/directory 2/" )
+echo ${OUT} | grep object
+echo ${OUT} | grep "other one"
+
 ${AWS} s3 cp bigfile s3://${BUCKET}/subdir/bigfile
 
 ${AWS} s3 cp s3://${BUCKET}/subdir/bigfile testfile

--- a/tests/unit/common/middleware/test_container_hierarchy.py
+++ b/tests/unit/common/middleware/test_container_hierarchy.py
@@ -105,6 +105,23 @@ class OioContainerHierarchy(unittest.TestCase):
         data = json.loads(resp[2])
         self.assertEqual(data[0]['name'], 'd1/d2/d3/o')
 
+    def test_listing_with_space(self):
+        self.ch.conn.keys = mock.MagicMock(return_value=['CS:a:cnt:d 1/d2/'])
+        self.app.register(
+            'GET',
+            '/v1/a/c%2Fd 1%2Fd2?prefix=&limit=10000&delimiter=%2F&format=json', # noqa
+            swob.HTTPOk, {},
+            json.dumps([{"hash": "d41d8cd98f00b204e9800998ecf8427e",
+                         "last_modified": "2018-04-20T09:40:59.000000",
+                         "bytes": 0, "name": "o",
+                         "content_type": "application/octet-stream"}]))
+
+        req = Request.blank('/v1/a/c?prefix=d%201%2Fd2%2F', method='GET')
+        resp = self.call_ch(req)
+
+        data = json.loads(resp[2])
+        self.assertEqual(data[0]['name'], 'd 1/d2/o')
+
     def test_global_listing(self):
         self.app.register(
             'GET', '/v1/a', swob.HTTPOk, {})


### PR DESCRIPTION
When an intermediary container is created with space, it is used on container name.
But when listing this container, the space was first converted to `+` with `quote_plus` and then again converted later to `%2B` in `urllib3.request` before sending request.

JIRA: OS-216