### PR TITLE
Container Hierarchy: save bucket name in metadata

### DIFF
--- a/oioswift/common/middleware/container_hierarchy.py
+++ b/oioswift/common/middleware/container_hierarchy.py
@@ -476,6 +476,7 @@ class ContainerHierarchyMiddleware(AutoContainerBase):
             env2['HTTP_OIO_COPY_FROM'] = '/' + c_container + '/' + c_obj
 
     def __call__(self, env, start_response):
+        self._save_bucket_name(env)
         if self.should_bypass(env):
             return self.app(env, start_response)
 


### PR DESCRIPTION
The `e8634f7f5e02690548b5e8f12ae2513d3e586d99` changes on Container Hierarchy on new version.
The test was here but hidden in all logs