### PR TITLE
ContainerHierarchy: improve redis scan

### DIFF
--- a/oioswift/common/middleware/container_hierarchy.py
+++ b/oioswift/common/middleware/container_hierarchy.py
@@ -75,7 +75,7 @@ class RedisDb(object):
         return self.conn.delete(key)
 
     def keys(self, pattern):
-        return self.conn.scan_iter(pattern)
+        return self.conn.scan_iter(pattern, count=5000)
 
     def exists(self, key):
         return self.conn.exists(key)


### PR DESCRIPTION
By default, scan_iter use `count` with 10 that make lot of
requests between gateway and redis that impact listing performance.