### PR TITLE
Trap ServiceUnavailable exceptions

### DIFF
--- a/oioswift/utils.py
+++ b/oioswift/utils.py
@@ -19,8 +19,8 @@ from swift.common.swob import HTTPMethodNotAllowed, \
     HTTPNotFound, \
     HTTPNotModified, HTTPPreconditionFailed, HTTPServiceUnavailable
 
-from oio.common.exceptions import ServiceBusy, NoSuchContainer, NoSuchObject,\
-    OioTimeout
+from oio.common.exceptions import NoSuchContainer, NoSuchObject,\
+    OioTimeout, ServiceBusy, ServiceUnavailable
 try:
     # Since oio-sds 4.1.14
     from oio.common.exceptions import MethodNotAllowed
@@ -98,11 +98,11 @@ def handle_service_busy(fnc):
     def _service_busy_wrapper(self, req, *args, **kwargs):
         try:
             return fnc(self, req, *args, **kwargs)
-        except ServiceBusy as e:
+        except (ServiceBusy, ServiceUnavailable) as err:
             headers = dict()
             headers['Retry-After'] = '1'
             return HTTPServiceUnavailable(request=req, headers=headers,
-                                          body=e.message)
+                                          body=err.message)
     return _service_busy_wrapper
 
 

--- a/runserver.py
+++ b/runserver.py
@@ -1,7 +1,34 @@
 import sys
+from optparse import OptionParser
 from swift.common.utils import parse_options
 from swift.common.wsgi import run_wsgi
 
+
+def run_objgraph(types):
+    import objgraph
+    import os
+    import random
+    objgraph.show_most_common_types(limit=50, shortnames=False)
+    for type_ in types:
+        count = objgraph.count(type_)
+        print '%s objects: %d' % (type_, count)
+        if count:
+            objgraph.show_backrefs(
+                random.choice(objgraph.by_type(type_)), max_depth=20,
+                filename='/tmp/backrefs_%s_%d.dot' % (type_, os.getpid()))
+
+
 if __name__ == '__main__':
-    conf_file, options = parse_options()
-    sys.exit(run_wsgi(conf_file, 'proxy-server', **options))
+    parser = OptionParser(usage="%prog CONFIG [options]")
+    parser.add_option('--objgraph', action='store_true',
+                      help=('Run objgraph, show most common '
+                            'types before exiting'))
+    parser.add_option('--show-backrefs', action='append', default=list(),
+                      help=('Draw backreference graph for one randomly '
+                            'chosen object of that type. Can be used '
+                            'multiple times.'))
+    conf_file, options = parse_options(parser)
+    res = run_wsgi(conf_file, 'proxy-server', **options)
+    if options.get('objgraph'):
+        run_objgraph(options.get('show_backrefs', list()))
+    sys.exit(res)


### PR DESCRIPTION
These exceptions are raised when some chunks are not available (but not
necessarily lost). Proper usage of ServiceUnavailable exceptions has
been implemented in oio-sds 4.2.7.

Jira: OS-263