### PR TITLE
tests: add test using s3cmd

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,4 +6,5 @@ mock
 nose
 nose-timer
 oio>=4.1.0
+s3cmd
 unittest2

--- a/tests/functional/common.sh
+++ b/tests/functional/common.sh
@@ -79,6 +79,26 @@ s3 =
 EOF
 }
 
+function configure_s3cmd() {
+    cat <<EOF >"$HOME/.s3cfg"
+[default]
+access_key = demo:demo
+bucket_location = us-east-1
+default_mime_type = binary/octet-stream
+host_base = localhost:5000
+host_bucket = no
+multipart_chunk_size_mb = 5
+multipart_max_chunks = 10000
+preserve_attrs = True
+progress_meter = False
+secret_key = DEMO_PASS
+signature_v2 = True
+signurl_use_https = False
+use_https = False
+verbosity = WARNING
+EOF
+}
+
 function configure_oioswift() {
     sed -i "s/USER/$(id -un)/g" "$1"
 }

--- a/tests/functional/run-s3-tests.sh
+++ b/tests/functional/run-s3-tests.sh
@@ -8,6 +8,7 @@ install_deps
 compile_sds
 run_sds
 configure_aws
+configure_s3cmd
 
 RET=0
 
@@ -15,7 +16,7 @@ run_functional_test s3-container-hierarchy.cfg s3_container_hierarchy_v2.sh
 run_functional_test s3-fastcopy.cfg s3-acl-metadata.sh
 # Run all suites in the same environment.
 # They do not share buckets so this should be OK.
-run_functional_test s3-default.cfg s3-acl-metadata.sh s3-versioning.sh s3-tagging.sh s3-multipart.sh
+run_functional_test s3-default.cfg s3-acl-metadata.sh s3-versioning.sh s3-tagging.sh s3-multipart.sh s3-s3cmd.sh
 
 # TODO(FVE): gridinit_cmd stop
 exit $RET

--- a/tests/functional/s3-s3cmd.sh
+++ b/tests/functional/s3-s3cmd.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+S3CMD="s3cmd"
+AWS="aws --endpoint-url http://localhost:5000 --no-verify-ssl"
+
+BUCKET=bucket-$RANDOM
+
+echo "Bucket name: $BUCKET"
+
+set -e
+
+${S3CMD} mb s3://${BUCKET}
+
+echo "Upload a file with Content-Type text/plain"
+${S3CMD} put /etc/passwd s3://${BUCKET} --content-type "text/plain"
+
+echo "Check Content-Type is text/plain"
+contenttype=$(${AWS} s3api head-object --bucket ${BUCKET} --key passwd | jq .ContentType)
+[ ${contenttype} = '"text/plain"' ]
+
+echo Modify object by adding a new header
+${S3CMD} modify s3://${BUCKET}/passwd --add-header "X-Content":"test"
+
+echo "Check Content-Type is not updated"
+contenttype=$(${AWS} s3api head-object --bucket ${BUCKET} --key passwd | jq .ContentType)
+[ ${contenttype} = '"text/plain"' ]
+
+${S3CMD} rm s3://${BUCKET}/passwd
+
+${S3CMD} rb s3://${BUCKET}


### PR DESCRIPTION
The test added exhibits issue resolved with https://github.com/open-io/swift3/pull/49
where content-type of ACL put object is misused and replace
object content-type.