### PR TITLE
HashedContainer: allow skipping metadata retrievals

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ env:
     - TEST_SUITE=encryption
     - TEST_SUITE=encryption SDS_BRANCH=master
     - TEST_SUITE=encryption SDS_BRANCH=4.2.x SWIFT_BRANCH=stable/pike
+    - TEST_SUITE=swift
+    - TEST_SUITE=swift SDS_BRANCH=4.2.x SWIFT_BRANCH=stable/pike
     - TEST_SUITE=ns-wide-versioning
     - TEST_SUITE=ns-wide-versioning SDS_BRANCH=4.2.x SWIFT_BRANCH=stable/pike
     - TEST_SUITE=unit

--- a/conf/default.cfg
+++ b/conf/default.cfg
@@ -132,6 +132,11 @@ use = egg:oioswift#hashedcontainer
 # (equivalent to "ns.flat_bits" namespace parameter).
 #bits=17
 
+# Skip account and container metadata retrievals.
+# This can improve performance if this metadata is not used.
+# Enable only if neither authentication nor quota are enabled.
+#skip_metadata = false
+
 
 [filter:regexcontainer]
 use = egg:oioswift#regexcontainer

--- a/conf/swift-flatns-skip-metadata.cfg
+++ b/conf/swift-flatns-skip-metadata.cfg
@@ -1,0 +1,55 @@
+[DEFAULT]
+bind_port = 5000
+workers = 1
+user = USER
+log_facility = LOG_LOCAL0
+log_level = NOTICE
+eventlet_debug = true
+sds_default_account = AUTH_demo
+
+[pipeline:main]
+pipeline = catch_errors cache proxy-logging slo hashedcontainer proxy-server
+
+[app:proxy-server]
+use = egg:oioswift#main
+allow_account_management = true
+account_autocreate = true
+sds_namespace = OPENIO
+sds_proxy_url = http://127.0.0.1:6000
+object_post_as_copy = false
+log_name = OIO,NS,oioswift,1
+sds_connection_timeout=5
+sds_read_timeout=5
+sds_write_timeout=5
+
+[filter:hashedcontainer]
+use = egg:oioswift#hashedcontainer
+bits = 15
+strip_v1 = false
+swift3_compat = false
+account_first = false
+default_account = myaccount
+sds_namespace = OPENIO
+sds_proxy_url = http://127.0.0.1:6000
+skip_metadata = true
+
+[filter:gatekeeper]
+use = egg:swift#gatekeeper
+
+[filter:proxy-logging]
+use = egg:swift#proxy_logging
+
+[filter:catch_errors]
+use = egg:swift#catch_errors
+
+[filter:cache]
+use = egg:swift#memcache
+memcache_servers = 127.0.0.1:11211
+
+[filter:slo]
+use = egg:swift#slo
+
+[filter:versioned_writes]
+use = egg:oioswift#versioned_writes
+allow_versioned_writes = false
+

--- a/oioswift/common/middleware/hashedcontainer.py
+++ b/oioswift/common/middleware/hashedcontainer.py
@@ -27,9 +27,10 @@ class HashedContainerMiddleware(AutoContainerBase):
 
     def __init__(self, app, ns, acct, proxy=None,
                  strip_v1=False, account_first=False,
-                 **kwargs):
+                 skip_metadata=False, **kwargs):
         super(HashedContainerMiddleware, self).__init__(
-            app, acct, strip_v1=strip_v1, account_first=account_first)
+            app, acct, strip_v1=strip_v1, account_first=account_first,
+            skip_metadata=skip_metadata)
         conf = {"namespace": ns, "proxyd_url": proxy}
         try:
             # New API (openio-sds >= 4.2)
@@ -64,10 +65,12 @@ def filter_factory(global_conf, **local_config):
 
     strip_v1 = config_true_value(local_config.pop('strip_v1', False))
     account_first = config_true_value(local_config.pop('account_first', False))
+    skip_metadata = config_true_value(local_config.pop('skip_metadata', False))
 
     def factory(app):
         return HashedContainerMiddleware(app, ns, acct, proxy,
                                          strip_v1=strip_v1,
                                          account_first=account_first,
+                                         skip_metadata=skip_metadata,
                                          **local_config)
     return factory

--- a/tests/functional/common.sh
+++ b/tests/functional/common.sh
@@ -122,10 +122,10 @@ function run_functional_test() {
     for suite in $test_suites
     do
       if bash "$suite"; then
-        printf "${GREEN}\n${suite}: OK\n${NO_COLOR}"
+        printf "${GREEN}\n${suite}: OK\n${NO_COLOR} ($conf)"
       else
         RET=1
-        printf "${RED}\n${suite}: FAILED\n${NO_COLOR}"
+        printf "${RED}\n${suite}: FAILED\n${NO_COLOR} ($conf)"
       fi
     done
 

--- a/tests/functional/common.sh
+++ b/tests/functional/common.sh
@@ -115,7 +115,7 @@ function run_functional_test() {
     local test_suites=$(for suite in $*; do echo "tests/functional/${suite}"; done)
     configure_oioswift $conf
 
-    coverage run -p runserver.py $conf -v &
+    coverage run -p runserver.py $conf -v 2>&1 | tee /tmp/journal.log &
     sleep 1
     PID=$(jobs -p)
 

--- a/tests/functional/run-swift-tests.sh
+++ b/tests/functional/run-swift-tests.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+source tests/functional/common.sh
+
+export OIO_NS="OPENIO" OIO_ACCOUNT="test_account" OIO_USER=USER-$RANDOM OIO_PATH=PATH-$RANDOM
+
+install_deps
+compile_sds
+run_sds
+
+RET=0
+
+run_functional_test swift-flatns-skip-metadata.cfg swift-skip-metadata.sh
+
+# TODO(FVE): gridinit_cmd stop
+exit $RET

--- a/tests/functional/swift-skip-metadata.sh
+++ b/tests/functional/swift-skip-metadata.sh
@@ -11,7 +11,7 @@ sleep 5
 curl -XPUT http://localhost:5000/example/pass --data-binary @/etc/magic
 
 # read object
-curl -XGET http://localhost:5000/example/pass --data-binary @/etc/magic --output /dev/null
+curl -XGET http://localhost:5000/example/pass
 
 # overwrite object
 curl -XPUT http://localhost:5000/example/pass --data-binary @/etc/magic

--- a/tests/functional/swift-skip-metadata.sh
+++ b/tests/functional/swift-skip-metadata.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+RET=0
+set -e
+
+ACCOUNT=$(openio cluster list account -c Addr -f value)
+openio cluster lock account ${ACCOUNT}
+sleep 5
+
+# prepare object
+curl -XPUT http://localhost:5000/example/pass --data-binary @/etc/magic
+
+# read object
+curl -XGET http://localhost:5000/example/pass --data-binary @/etc/magic --output /dev/null
+
+# overwrite object
+curl -XPUT http://localhost:5000/example/pass --data-binary @/etc/magic
+
+# check in journal that "found only 0 services matching the criteria" is not present
+if grep "found only 0 services matching the criteria" /tmp/journal.log; then
+    echo "Account was still used by swift"
+    RET=1
+fi
+
+openio cluster unlock account ${ACCOUNT}
+sleep 5
+
+exit $RET


### PR DESCRIPTION
Depending on how the gateway is used, it may make sense to skip `account` and `container` metadata retrievals (no quota and no authentication in the pipeline).