### PR TITLE
ContainerHierarchy: fix listing with : in object

### DIFF
--- a/oioswift/common/middleware/container_hierarchy.py
+++ b/oioswift/common/middleware/container_hierarchy.py
@@ -268,7 +268,7 @@ class ContainerHierarchyMiddleware(AutoContainerBase):
 
         prefix_key = self.key(account, container, "")
         key = self.key(account, container, '*', prefix) + '*'
-        matches = [k[len(prefix_key):].split(':', 2)
+        matches = [k[len(prefix_key):].split(':', 1)
                    for k in self.conn.keys(key)]
 
         LOG.debug("SHARD: prefix %s / matches: %s", prefix_key, matches)

--- a/oioswift/proxy/controllers/container.py
+++ b/oioswift/proxy/controllers/container.py
@@ -85,15 +85,15 @@ class ContainerController(SwiftContainerController):
     def convert_policy(self, resp):
         if 'X-Backend-Storage-Policy-Index' in resp.headers and \
                 is_success(resp.status_int):
-                    policy = self.app.POLICIES.get_by_index(
-                        resp.headers['X-Backend-Storage-Policy-Index'])
-                    if policy:
-                        resp.headers['X-Storage-Policy'] = policy.name
-                    else:
-                        self.app.logger.error(
-                            'Could not translate %s (%r) from %r to policy',
-                            'X-Backend-Storage-Policy-Index',
-                            resp.headers['X-Backend-Storage-Policy-Index'])
+            policy = self.app.POLICIES.get_by_index(
+                resp.headers['X-Backend-Storage-Policy-Index'])
+            if policy:
+                resp.headers['X-Storage-Policy'] = policy.name
+            else:
+                self.app.logger.error(
+                    'Could not translate %s (%r) from %r to policy',
+                    'X-Backend-Storage-Policy-Index',
+                    resp.headers['X-Backend-Storage-Policy-Index'])
         return resp
 
     def get_metadata_resp_headers(self, meta):

--- a/tests/functional/s3_container_hierarchy_v2.sh
+++ b/tests/functional/s3_container_hierarchy_v2.sh
@@ -41,6 +41,21 @@ echo ${OUT} | grep small
 echo ${OUT} | grep root
 echo ${OUT} | grep dir1/dir2/object
 
+# LISTING WITH : (simulate cloudberry)
+
+d=$(date +%s)
+${AWS} s3api put-object --bucket ${BUCKET} --key key1/key2/dot:/${d}/
+
+OUT=$( ${AWS} s3 ls s3://${BUCKET}/key1/key2 )
+echo ${OUT} | grep key2/
+OUT=$( ${AWS} s3 ls s3://${BUCKET}/key1/key2/dot )
+echo ${OUT} | grep dot
+
+OUT=$( ${AWS} s3api list-objects --bucket ${BUCKET} )
+echo ${OUT} | grep dot
+OUT=$( ${AWS} s3api list-objects --bucket ${BUCKET} --prefix key1/key2/dot:/${d}/ )
+echo ${OUT} | grep dot
+
 
 # LISTING WITH SPACE
 
@@ -108,7 +123,7 @@ ${AWS} s3api put-object --bucket ${BUCKET} --key d1/d2/d3/d4/o2 --body aa
 ${AWS} s3api put-object --bucket ${BUCKET} --key v1/o2 --body aa
 sleep 0.5
 CNT=$( ${AWS} s3api list-objects --bucket ${BUCKET} | grep -c Key )
-[ "$CNT" -eq 10 ]
+[ "$CNT" -eq 11 ]
 
 # COPY S3<=>S3
 


### PR DESCRIPTION
Some clients use `:` in PATH to mimic Windows behavior or use them as separator to custom versioning like Cloud Berry

Fixes OS-308