### PR TITLE
CH: add specific check for CloudBerry versioning

### DIFF
--- a/oioswift/common/middleware/container_hierarchy.py
+++ b/oioswift/common/middleware/container_hierarchy.py
@@ -467,7 +467,7 @@ class ContainerHierarchyMiddleware(AutoContainerBase):
 
         for obj in items:
             if 'name' in obj:
-                obj['name'] = obj_prefix + obj['name']
+                obj['name'] = obj_prefix.decode('utf-8') + obj['name']
                 yield obj
 
     def should_bypass(self, env):

--- a/oioswift/common/middleware/container_hierarchy.py
+++ b/oioswift/common/middleware/container_hierarchy.py
@@ -389,10 +389,20 @@ class ContainerHierarchyMiddleware(AutoContainerBase):
                 if len(item) > 32:
                     try:
                         base64.b64decode(item)
+                        # CloudBerry: mitigate number of container created
+                        if i >= 3:
+                            if obj_parts[i-3] == obj_parts[i-1] + ':':
+                                return sep.join(obj_parts[:i-3]), i-2
                         return sep.join(obj_parts[:i-1]), i
                     except TypeError:
                         pass
             LOG.error("MPU fails to detect UploadId")
+
+        # CloudBerry: mitigate number of container created
+        if len(obj_parts) >= 3:
+            if obj_parts[-1] + ':' == obj_parts[-3]:
+                return sep.join(obj_parts[:-3]), -2
+
         return sep.join(obj_parts[:-1]), len(obj_parts)
 
     def _fake_container_and_obj(self, container, obj_parts, is_listing=False,

--- a/tests/functional/s3_container_hierarchy_v2.sh
+++ b/tests/functional/s3_container_hierarchy_v2.sh
@@ -180,7 +180,10 @@ ${AWS} s3 cp s3://${BCK1}/root s3://${BCK2}/d1/d2/d3/bigfile
 # COPY SAME BUCKET
 ${AWS} s3 cp s3://${BCK1}/root s3://${BCK1}/same_bucket/bigfile
 
+# COPY WITF UTF-8 PATH
+${AWS} s3 cp s3://${BCK1}/root s3://${BCK1}/répertoire/bigfile
 
+${AWS} s3api list-objects --bucket ${BCK1}
 
 echo "OK"
 


### PR DESCRIPTION
Catch versioning introduced by CloudBerry Backup to avoid one container per version and object

Fixes OS-323