### PR TITLE
ContainerHierarchy: force listing on master

### DIFF
--- a/oioswift/common/middleware/container_hierarchy.py
+++ b/oioswift/common/middleware/container_hierarchy.py
@@ -192,7 +192,8 @@ class ContainerHierarchyMiddleware(AutoContainerBase):
                             account,
                             [container] + path.split('/'),
                             None,
-                            limit=1))
+                            limit=1,
+                            force_master=True))
 
             if not empty:
                 return
@@ -417,7 +418,7 @@ class ContainerHierarchyMiddleware(AutoContainerBase):
 
     def _list_objects(self, env, account, ct_parts, header_cb,
                       prefix='', limit=DEFAULT_LIMIT,
-                      marker=None):
+                      marker=None, force_master=False):
         """
         returns items
         """
@@ -439,6 +440,9 @@ class ContainerHierarchyMiddleware(AutoContainerBase):
             params['marker'] = marker
         else:
             params.pop('marker', None)
+        if force_master:
+            sub_req.environ.setdefault('oio.query', {})
+            sub_req.environ['oio.query']['force_master'] = True
 
         sub_req.params = params
         resp = sub_req.get_response(self.app)

--- a/oioswift/proxy/controllers/container.py
+++ b/oioswift/proxy/controllers/container.py
@@ -147,6 +147,7 @@ class ContainerController(SwiftContainerController):
             end_marker=end_marker, properties=True,
             versions=opts.get('versions', False),
             deleted=opts.get('deleted', False),
+            force_master=opts.get('force_master', False),
             headers=oio_headers)
 
         resp_headers = self.get_metadata_resp_headers(result)


### PR DESCRIPTION
After removing an object, the listing to check removal of key will now
be forced to occurs on master to avoid unsynchronized use of slave.

It requires https://github.com/open-io/oio-sds/pull/1677

Fixes OS-331