### PR TITLE
CH: Redis improvement and marker fixes

### DIFF
--- a/tests/functional/common.sh
+++ b/tests/functional/common.sh
@@ -55,14 +55,7 @@ function run_sds() {
     -f third_party/oio-sds/etc/bootstrap-preset-SINGLE.yml \
     -f third_party/oio-sds/etc/bootstrap-meta1-1digits.yml \
     -f third_party/oio-sds/etc/bootstrap-option-cache.yml
-  openio cluster wait
-  SUCCESS=$?
-  if [ ! $SUCCESS ]
-  then
-    # Help seeing what is wrong
-    openio cluster list
-  fi
-  return $SUCCESS
+  openio cluster wait || (openio cluster list --stats; gridinit_cmd -S ~/.oio/sds/run/gridinit.sock status2; return 1)
 }
 
 function configure_aws() {

--- a/tests/functional/run-encryption-tests.sh
+++ b/tests/functional/run-encryption-tests.sh
@@ -5,9 +5,9 @@
 source tests/functional/common.sh
 
 export OIO_NS="OPENIO" OIO_ACCOUNT="AUTH_demo" OIO_USER=USER-$RANDOM OIO_PATH=PATH-$RANDOM
-install_deps
-compile_sds
-run_sds
+install_deps || exit 1
+compile_sds || exit 1
+run_sds || exit 1
 configure_aws
 
 RET=0

--- a/tests/functional/run-ns-wide-versioning-tests.sh
+++ b/tests/functional/run-ns-wide-versioning-tests.sh
@@ -23,7 +23,7 @@ compile_sds || exit 1
 run_sds || exit 1
 
 coverage run -p runserver.py conf/hashed-containers.cfg -v &
-sleep 1
+sleep 2
 PID=$(jobs -p)
 
 bash tests/functional/ns-wide-versioning-tests.sh "$OIO_NS" "$OIO_ACCOUNT"

--- a/tests/functional/run-ns-wide-versioning-tests.sh
+++ b/tests/functional/run-ns-wide-versioning-tests.sh
@@ -18,9 +18,9 @@ function run_sds() {
 }
 
 export OIO_NS="OPENIO" OIO_ACCOUNT="test_account" OIO_USER=USER-$RANDOM OIO_PATH=PATH-$RANDOM
-install_deps
-compile_sds
-run_sds
+install_deps || exit 1
+compile_sds || exit 1
+run_sds || exit 1
 
 coverage run -p runserver.py conf/hashed-containers.cfg -v &
 sleep 1

--- a/tests/functional/run-s3-tests.sh
+++ b/tests/functional/run-s3-tests.sh
@@ -12,13 +12,13 @@ configure_s3cmd
 
 RET=0
 
-run_functional_test s3-container-hierarchy.cfg s3_container_hierarchy_v2.sh
-run_functional_test s3-container-hierarchy-key-v2.cfg s3_container_hierarchy_v2.sh
-run_functional_test s3-fastcopy.cfg s3-acl-metadata.sh
+run_functional_test s3-container-hierarchy.cfg s3_container_hierarchy_v2.sh s3-marker.sh
+run_functional_test s3-container-hierarchy-key-v2.cfg s3_container_hierarchy_v2.sh s3-marker.sh
+run_functional_test s3-fastcopy.cfg s3-acl-metadata.sh s3-marker.sh
 # Run all suites in the same environment.
 # They do not share buckets so this should be OK.
-run_functional_test s3-default.cfg s3-acl-metadata.sh s3-versioning.sh s3-tagging.sh s3-multipart.sh s3-s3cmd.sh
-bash tests/functional/s3_conversion_hierarchy.sh
+run_functional_test s3-default.cfg s3-acl-metadata.sh s3-versioning.sh s3-tagging.sh s3-multipart.sh s3-s3cmd.sh s3-marker.sh
+run_script tests/functional/s3_conversion_hierarchy.sh
 
 # TODO(FVE): gridinit_cmd stop
 exit $RET

--- a/tests/functional/run-s3-tests.sh
+++ b/tests/functional/run-s3-tests.sh
@@ -4,9 +4,9 @@ source tests/functional/common.sh
 
 export OIO_NS="OPENIO" OIO_ACCOUNT="test_account" OIO_USER=USER-$RANDOM OIO_PATH=PATH-$RANDOM
 
-install_deps
-compile_sds
-run_sds
+install_deps || exit 1
+compile_sds || exit 1
+run_sds || exit 1
 configure_aws
 configure_s3cmd
 

--- a/tests/functional/run-swift-tests.sh
+++ b/tests/functional/run-swift-tests.sh
@@ -4,9 +4,9 @@ source tests/functional/common.sh
 
 export OIO_NS="OPENIO" OIO_ACCOUNT="test_account" OIO_USER=USER-$RANDOM OIO_PATH=PATH-$RANDOM
 
-install_deps
-compile_sds
-run_sds
+install_deps || exit 1
+compile_sds || exit 1
+run_sds || exit 1
 
 RET=0
 

--- a/tests/functional/s3-marker.sh
+++ b/tests/functional/s3-marker.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+AWS="aws --endpoint-url http://localhost:5000"
+BUCKET="bucket-${RANDOM}"
+
+set -e
+
+count() {
+    local args=
+    if [ "$1" != "" ]; then
+        args="$args --start-after $1"
+    fi
+    count=$(${AWS} s3api list-objects-v2 --bucket ${BUCKET} $args | grep -c Key)
+    echo $count
+}
+
+${AWS} s3 mb s3://$BUCKET
+
+# create few items
+${AWS} s3 cp /etc/magic s3://${BUCKET}/bb
+${AWS} s3 cp /etc/magic s3://${BUCKET}/dd/dd
+${AWS} s3 cp /etc/magic s3://${BUCKET}/ff
+
+echo "Global listing"
+[ $(count) -eq 3 ] || exit 1
+
+echo "before first item"
+[ $(count aa) -eq 3 ] || exit 1
+
+echo "after first item"
+[ $(count bb) -eq 2 ] || exit 1
+
+echo "between first and second item"
+[ $(count cc) -eq 2 ] || exit 1
+
+echo "after second item"
+[ $(count dd/dd) -eq 1 ] || exit 1
+
+echo "between second and third item"
+[ $(count ee) -eq 1 ] || exit 1
+
+echo "after third item"
+[ $(count zz) -eq 0 ] || exit 1
+
+# cleanup
+${AWS} s3 rm s3://${BUCKET}/bb
+${AWS} s3 rm s3://${BUCKET}/dd/dd
+${AWS} s3 rm s3://${BUCKET}/ff
+
+${AWS} s3 rb s3://${BUCKET}

--- a/tests/unit/common/middleware/test_container_hierarchy.py
+++ b/tests/unit/common/middleware/test_container_hierarchy.py
@@ -324,6 +324,15 @@ class OioContainerHierarchy(unittest.TestCase):
         self._test_listing_with_marker()
 
     def _test_listing_with_marker(self):
+        # register root container
+        self.app.register(
+            'GET',
+            '/v1/a/bucket?marker=d1&prefix=&limit=10000&format=json',
+            swob.HTTPOk, {},
+            json.dumps([{"hash": "d41d8cd98f00b204e9800998ecf8427e",
+                         "last_modified": "2018-04-20T09:40:59.000000",
+                         "bytes": 0, "name": "zz",
+                         "content_type": "application/octet-stream"}]))
         req = Request.blank('/v1/a/bucket?limit=10&delimiter=%2F&marker=d1/',
                             method='GET')
         resp = self.call_ch(req)
@@ -331,6 +340,7 @@ class OioContainerHierarchy(unittest.TestCase):
                  for item in json.loads(resp[2])]
         self.assertNotIn('d1/', names)
         self.assertIn('d2/', names)
+        self.assertIn('zz', names)
 
     def test_listing_with_marker_multi_container_v1(self):
         self.ch.redis_keys_format = REDIS_KEYS_FORMAT_V1
@@ -348,6 +358,15 @@ class OioContainerHierarchy(unittest.TestCase):
         self._test_listing_with_marker_multi_container()
 
     def _test_listing_with_marker_multi_container(self):
+        # register root container
+        self.app.register(
+            'GET',
+            '/v1/a/bucket?marker=d1&prefix=&limit=10000&format=json',
+            swob.HTTPOk, {},
+            json.dumps([{"hash": "d41d8cd98f00b204e9800998ecf8427e",
+                         "last_modified": "2018-04-20T09:40:59.000000",
+                         "bytes": 0, "name": "zz",
+                         "content_type": "application/octet-stream"}]))
         # with marker aa (as we inspect d1/)
         self.app.register(
             'GET',
@@ -373,6 +392,7 @@ class OioContainerHierarchy(unittest.TestCase):
                  for item in json.loads(resp[2])]
         self.assertIn('d1/d0', names)
         self.assertIn('d2/d0', names)
+        self.assertIn('zz', names)
 
     def test_duplicate_obj_cnt(self):
         self.ch.redis_keys_format = REDIS_KEYS_FORMAT_V1
@@ -388,6 +408,10 @@ class OioContainerHierarchy(unittest.TestCase):
         self._test_duplicate_obj_cnt()
 
     def _test_duplicate_obj_cnt(self):
+        self.app.register(
+            'GET',
+            '/v1/a/bucket?marker=d1&prefix=&limit=10000&format=json',
+            swob.HTTPOk, {}, json.dumps([]))
         req = Request.blank('/v1/a/bucket?limit=10&delimiter=%2F&marker=d1/',
                             method='GET')
         resp = self.call_ch(req)


### PR DESCRIPTION
By default, all REDIS operations occurred on `master`: since the most used operations is `READ` for listing request, now theses operations will be done on `slave`.

It could be managed by a flag if a customer prefer consistency over performance.


This PR also fix invalid marker:
- marker without / was not managed
- marker with / always ignored root container that led to ignore objects stored in it