### PR TITLE
CH: Optimize directory objects

### DIFF
--- a/conf/s3-container-hierarchy-key-v2.cfg
+++ b/conf/s3-container-hierarchy-key-v2.cfg
@@ -95,4 +95,4 @@ strip_v1 = true
 swift3_compat = true
 account_first = true
 redis_host = 127.0.0.1:6379
-redis_format_keys = v2
+redis_keys_format = v2

--- a/oioswift/common/middleware/container_hierarchy.py
+++ b/oioswift/common/middleware/container_hierarchy.py
@@ -104,7 +104,8 @@ class RedisDb(object):
         return self.conn_slave.scan_iter(pattern, count=count)
 
     def hkeys(self, key, match=None, count=DEFAULT_LIMIT):
-        return self.conn_slave.hscan_iter(key, match=match, count=count)
+        return [k[0] for k in
+                self.conn_slave.hscan_iter(key, match=match, count=count)]
 
     def exists(self, key):
         return self.conn_slave.exists(key)
@@ -262,7 +263,6 @@ class ContainerHierarchyMiddleware(AutoContainerBase):
         else:
             key = self.key(account, container, mode)
 
-        key = self.key(account, container, mode, path) + '/'
         if mode == CNT:
             # remove container key only if empty
             empty = not any(self._list_objects(

--- a/tests/functional/s3_container_hierarchy_v2.sh
+++ b/tests/functional/s3_container_hierarchy_v2.sh
@@ -162,6 +162,10 @@ sleep 0.5
 CNT=$( ${AWS} s3api list-objects --bucket ${BUCKET} | grep -c Key )
 [ "$CNT" -eq 13 ]
 
+# Check HEAD on directory "Object"
+${AWS} s3api put-object  --bucket ${BUCKET} --key dir1/dir2/
+${AWS} s3api head-object --bucket ${BUCKET} --key dir1/dir2/
+
 # COPY S3<=>S3
 
 BCK1=bucket-${RANDOM}
@@ -182,7 +186,7 @@ ${AWS} s3 cp s3://${BCK1}/root s3://${BCK2}/d1/d2/d3/bigfile
 # COPY SAME BUCKET
 ${AWS} s3 cp s3://${BCK1}/root s3://${BCK1}/same_bucket/bigfile
 
-# COPY WITF UTF-8 PATH
+# COPY WITH UTF-8 PATH
 ${AWS} s3 cp s3://${BCK1}/root s3://${BCK1}/répertoire/bigfile
 
 ${AWS} s3api list-objects --bucket ${BCK1}

--- a/tests/unit/common/middleware/test_container_hierarchy.py
+++ b/tests/unit/common/middleware/test_container_hierarchy.py
@@ -85,6 +85,8 @@ class OioContainerHierarchy(unittest.TestCase):
             mock.ANY, 'a', 'c', 'obj', 'd1/d2/d3/')
 
     def test_get(self):
+        if self.ch.redis_keys_format == REDIS_KEYS_FORMAT_V1:
+            self.ch.conn.set("CS:a:c:cnt:d1/d2/d3/", 1)
         self.app.register(
             'GET', '/v1/a/c%2Fd1%2Fd2%2Fd3/o', swob.HTTPOk, {})
         req = Request.blank('/v1/a/c/d1/d2/d3/o', method='GET')


### PR DESCRIPTION
This PR add fixes and enhancements regarding Container Hierarchy and how fake directories are managed.

Previously, the "directory" object was managed by listing, `DELETE` and `PUT`.
Any `GET` or `HEAD` requests were still forwarded to `sds`:

Now, `GET` or `HEAD` request with "directory" object will check in `redis` to response 200 or 404.
Any requests `HEAD` or `GET` on object (normal or directory object without trailing /) will check if container  exists in `redis` to bypass lookup in sds if it is unavailable.