### PR TITLE
CH: fix invalid use of marker

### DIFF
--- a/oioswift/common/middleware/container_hierarchy.py
+++ b/oioswift/common/middleware/container_hierarchy.py
@@ -401,18 +401,17 @@ class ContainerHierarchyMiddleware(AutoContainerBase):
                     matches.append((mode, entry))
                     continue
                 if entry < marker_:
-                    #  if entry != "" or not marker_root:
-                    #     LOG.debug("%s: marker ignore %s: before)",
-                    #               self.SWIFT_SOURCE, entry)
                     continue
-                if entry == marker_ + '/' and not recursive:
-                    # marker is something like d1/ but we d1/d2/d3/ key
-                    LOG.debug("%s: marker ignore %s: not recursive",
-                              self.SWIFT_SOURCE, entry)
+                # when a listing is done without recursive mode, ignore marker
+                # for container entry
+                if mode == CNT and entry == marker and not recursive:
+                    LOG.debug(
+                        "%s: marker ignore %s: skip container (not recursive)",
+                        self.SWIFT_SOURCE, entry)
                     continue
                 if mode == OBJ and entry == marker_ + '/':
                     LOG.debug("%s: marker ignore %s: skip object",
-                              self.SWIFT_SOURCE, entry, marker_)
+                              self.SWIFT_SOURCE, entry)
                     continue
                 matches.append((mode, entry))
         matches.sort()

--- a/tests/functional/s3-marker.sh
+++ b/tests/functional/s3-marker.sh
@@ -47,4 +47,74 @@ ${AWS} s3 rm s3://${BUCKET}/bb
 ${AWS} s3 rm s3://${BUCKET}/dd/dd
 ${AWS} s3 rm s3://${BUCKET}/ff
 
+
+# test marker with prefix on object
+
+for i in $(seq 1 21); do
+    ${AWS} s3 cp /etc/magic s3://${BUCKET}/subdir/object-$i
+done
+
+echo "Recursive listing with default page-size"
+objs=$(${AWS} s3api list-objects --bucket ${BUCKET} | grep -c Key)
+[ $objs -eq 21 ] || exit 1
+
+echo "Recursive listing with page-size 10"
+objs=$(${AWS} s3api list-objects --bucket ${BUCKET} --page-size 10 | grep -c Key)
+[ $objs -eq 21 ] || exit 1
+
+echo "Recursive listing with page-size 10 and prefix with trailing /"
+objs=$(${AWS} s3api list-objects --bucket ${BUCKET} --page-size 10 --prefix subdir/ | grep -c Key)
+[ $objs -eq 21 ] || exit 1
+
+echo "Recursive listing with page-size 10 and prefix without /"
+objs=$(${AWS} s3api list-objects --bucket ${BUCKET} --page-size 10 --prefix subdir | grep -c Key)
+[ $objs -eq 21 ] || exit 1
+
+echo "Recursive listing with page-size 10, prefix with trailing / and delimiter /"
+objs=$(${AWS} s3api list-objects --bucket ${BUCKET} --page-size 10 --prefix subdir/ --delimiter / | grep -c Key)
+[ $objs -eq 21 ] || exit 1
+
+echo "Recursive listing with page-size 10, prefix without trailing / and delimiter /"
+objs=$(${AWS} s3api list-objects --bucket ${BUCKET} --page-size 10 --prefix subdir --delimiter / | grep -c '"Prefix"')
+[ $objs -eq 1 ] || exit 1
+
+# cleanup
+for i in $(seq 1 21); do
+    ${AWS} s3 rm s3://${BUCKET}/subdir/object-$i
+done
+
+# test marker with prefix on subdir
+
+for i in $(seq 1 21); do
+    ${AWS} s3 cp /etc/magic s3://${BUCKET}/subdir/subdir-$i/object-$i
+done
+
+echo "Recursive listing with default page-size"
+objs=$(${AWS} s3api list-objects --bucket ${BUCKET} | grep -c Key)
+[ $objs -eq 21 ] || exit 1
+
+echo "Recursive listing with page-size 10"
+objs=$(${AWS} s3api list-objects --bucket ${BUCKET} --page-size 10 | grep -c Key)
+[ $objs -eq 21 ] || exit 1
+
+echo "Recursive listing with page-size 10 and prefix with trailing /"
+objs=$(${AWS} s3api list-objects --bucket ${BUCKET} --page-size 10 --prefix subdir/ | grep -c Key)
+[ $objs -eq 21 ] || exit 1
+
+echo "Recursive listing with page-size 10 and prefix without trailing /"
+objs=$(${AWS} s3api list-objects --bucket ${BUCKET} --page-size 10 --prefix subdir | grep -c Key)
+[ $objs -eq 21 ] || exit 1
+
+echo "Recursive listing with page-size 10, prefix with trailing / and delimiter /"
+objs=$(${AWS} s3api list-objects --bucket ${BUCKET} --page-size 10 --prefix subdir/ --delimiter / | grep -c '"Prefix"')
+[ $objs -eq 21 ] || exit 1
+
+echo "Recursive listing with page-size 10, prefix without trailing / and delimiter /"
+objs=$(${AWS} s3api list-objects --bucket ${BUCKET} --page-size 10 --prefix subdir --delimiter / | grep -c '"Prefix"')
+[ $objs -eq 1 ] || exit 1
+
+# cleanup
+for i in $(seq 1 21); do
+    ${AWS} s3 rm s3://${BUCKET}/subdir/subdir-$i/object-$i
+done
 ${AWS} s3 rb s3://${BUCKET}

--- a/tests/unit/common/middleware/test_container_hierarchy.py
+++ b/tests/unit/common/middleware/test_container_hierarchy.py
@@ -317,7 +317,8 @@ class OioContainerHierarchy(unittest.TestCase):
     def test_listing_with_marker_v1(self):
         self.ch.redis_keys_format = REDIS_KEYS_FORMAT_V1
         self.ch.conn.keys = mock.MagicMock(
-            return_value=['CS:a:bucket:cnt:d1/',
+            return_value=['CS:a:bucket:cnt:d0/',
+                          'CS:a:bucket:cnt:d1/',
                           'CS:a:bucket:cnt:d2/'])
         self._test_listing_with_marker()
 
@@ -326,7 +327,7 @@ class OioContainerHierarchy(unittest.TestCase):
         self.ch.conn.keys = mock.MagicMock(
             return_value=['CS:a:bucket:cnt'])
         self.ch.conn.hkeys = mock.MagicMock(
-            return_value=['d1/', 'd2/'])
+            return_value=['d0/', 'd1/', 'd2/'])
         self._test_listing_with_marker()
 
     def _test_listing_with_marker(self):
@@ -344,6 +345,7 @@ class OioContainerHierarchy(unittest.TestCase):
         resp = self.call_ch(req)
         names = [item.get('name', item.get('subdir'))
                  for item in json.loads(resp[2])]
+        self.assertNotIn('d0/', names)
         self.assertNotIn('d1/', names)
         self.assertIn('d2/', names)
         self.assertIn('zz', names)


### PR DESCRIPTION
When a marker got a d1/object (with / delimiter), the d1/ was
skipped due to invalid check in marker management.