### PR TITLE
Handle more DeadlineReached exceptions from ObjectStorageApi

### DIFF
--- a/oioswift/proxy/controllers/obj.py
+++ b/oioswift/proxy/controllers/obj.py
@@ -498,7 +498,8 @@ class ObjectController(BaseObjectController):
             raise HTTPClientDisconnect(request=req)
         except exceptions.EtagMismatch:
             return HTTPUnprocessableEntity(request=req)
-        except (exceptions.ServiceBusy, exceptions.OioTimeout):
+        except (exceptions.ServiceBusy, exceptions.OioTimeout,
+                exceptions.DeadlineReached):
             raise
         except (exceptions.NoSuchContainer, exceptions.NotFound):
             raise HTTPNotFound(request=req)
@@ -597,7 +598,8 @@ class ObjectController(BaseObjectController):
             raise HTTPClientDisconnect(request=req)
         except exceptions.EtagMismatch:
             return HTTPUnprocessableEntity(request=req)
-        except (exceptions.ServiceBusy, exceptions.OioTimeout):
+        except (exceptions.ServiceBusy, exceptions.OioTimeout,
+                exceptions.DeadlineReached):
             raise
         except exceptions.NoSuchContainer:
             raise HTTPNotFound(request=req)


### PR DESCRIPTION
The commit f5e484a25613f29dd2d799d16fa8cd735d2bf4b0 implemented a global mechanism to intercept `DeadlineReached` exceptions. This commit ensures these exceptions reach the appropriate handler, and are not considered as dummy `ClientException`.