### PR TITLE
Various CH fixes

### DIFF
--- a/oioswift/common/middleware/container_hierarchy.py
+++ b/oioswift/common/middleware/container_hierarchy.py
@@ -114,7 +114,7 @@ class RedisDb(object):
                  -- there is no `continue` instruction on Lua
                  local check = true
                  if prefix ~= "" then
-                     local index = string.find(elem, prefix)
+                     local index = string.find(elem, prefix, 1, true)
                      if index == nil or index > 1 then
                          check = false
                      end

--- a/oioswift/common/middleware/container_hierarchy.py
+++ b/oioswift/common/middleware/container_hierarchy.py
@@ -440,7 +440,7 @@ class ContainerHierarchyMiddleware(AutoContainerBase):
                             None,
                             limit=1,
                             force_master=True,
-                            versions=self.support_listing_versioning))
+                            versions=True))
             if not empty:
                 return
 

--- a/tests/functional/run-s3-tests.sh
+++ b/tests/functional/run-s3-tests.sh
@@ -34,13 +34,17 @@ for key_format in v1 v2 v3; do
             run_functional_test $name s3-versioning-container-hierarchy.sh
         fi
     done
+
+     # only run conversion test on v1 keys
+     if [ "$key_format" == "v1" ]; then
+        run_script tests/functional/s3-conversion-container-hierarchy.sh
+    fi
 done
 
 run_functional_test s3-fastcopy.cfg s3-acl-metadata.sh s3-marker.sh
 # Run all suites in the same environment.
 # They do not share buckets so this should be OK.
 run_functional_test s3-default.cfg s3-acl-metadata.sh s3-tagging.sh s3-multipart.sh s3-s3cmd.sh buckets-listing.sh s3-marker.sh s3-basic-test.py
-run_script tests/functional/s3-conversion-container-hierarchy.sh
 
 # TODO(FVE): gridinit_cmd stop
 exit $RET


### PR DESCRIPTION
- The CH v3 with '-' in prefix was improperly tested in lua
- Always use a versioned listing before removing a redis entry
- Conversion script may fails as it may use v3 keys when await v1 keys