### PR TITLE
Report missing container when checking versioning mode

### DIFF
--- a/oioswift/common/middleware/container_hierarchy.py
+++ b/oioswift/common/middleware/container_hierarchy.py
@@ -396,7 +396,7 @@ class ContainerHierarchyMiddleware(AutoContainerBase):
                 ch_index < pipeline.index('versioned_writes')):
             raise ValueError(
                 'Invalid pipeline %r: '
-                '%s must be placed before versioned_writes'
+                '%s must be placed after versioned_writes'
                 % (pipeline, MIDDLEWARE_NAME))
 
     def key(self, account, container, mode, path=None):


### PR DESCRIPTION
When handling an object creation operation, and when the container supposed to host the object is missing, an unhandled exception was raised. This exception is now converted to a proper response error.

Also rename things and write documentation.