### PR TITLE
Properly pass request ID to oio API

### DIFF
--- a/oioswift/proxy/controllers/account.py
+++ b/oioswift/proxy/controllers/account.py
@@ -37,7 +37,8 @@ from swift.proxy.controllers.base import set_info_cache, clear_info_cache
 
 from oio.common import exceptions
 
-from oioswift.utils import handle_oio_timeout, handle_service_busy
+from oioswift.utils import handle_oio_timeout, handle_service_busy, \
+    REQID_HEADER
 
 
 def get_response_headers(info):
@@ -174,7 +175,7 @@ class AccountController(SwiftAccountController):
         if req.environ.get('swift.source') == 'S3':
             s3_buckets_only = True
 
-        oio_headers = {'X-oio-req-id': self.trans_id}
+        oio_headers = {REQID_HEADER: self.trans_id}
         info = None
         if hasattr(self.app.storage, 'account'):
             # Call directly AccountClient.container_list()
@@ -221,7 +222,7 @@ class AccountController(SwiftAccountController):
         return resp
 
     def get_account_head_resp(self, req):
-        oio_headers = {'X-oio-req-id': self.trans_id}
+        oio_headers = {REQID_HEADER: self.trans_id}
         info = self.app.storage.account_show(
             self.account_name, headers=oio_headers)
         return account_listing_response(self.account_name, req,
@@ -254,7 +255,7 @@ class AccountController(SwiftAccountController):
         return resp
 
     def get_account_put_resp(self, req, headers):
-        oio_headers = {'X-oio-req-id': self.trans_id}
+        oio_headers = {REQID_HEADER: self.trans_id}
         created = self.app.storage.account_create(
             self.account_name, headers=oio_headers)
         metadata = {}
@@ -298,7 +299,7 @@ class AccountController(SwiftAccountController):
         metadata.update((key, value)
                         for key, value in req.headers.items()
                         if is_sys_or_user_meta('account', key))
-        headers['X-oio-req-id'] = self.trans_id
+        headers[REQID_HEADER] = self.trans_id
         try:
             self.app.storage.account_set_properties(
                 account=self.account_name, properties=metadata,

--- a/oioswift/proxy/controllers/container.py
+++ b/oioswift/proxy/controllers/container.py
@@ -43,7 +43,7 @@ from oio.common import exceptions
 
 from oioswift.utils import \
     handle_oio_no_such_container, handle_oio_timeout, \
-    handle_service_busy
+    handle_service_busy, REQID_HEADER
 
 
 class ContainerController(SwiftContainerController):
@@ -140,7 +140,7 @@ class ContainerController(SwiftContainerController):
                 prefix = path.rstrip('/') + '/'
             delimiter = '/'
         opts = req.environ.get('oio.query', {})
-        oio_headers = {'X-oio-req-id': self.trans_id}
+        oio_headers = {REQID_HEADER: self.trans_id}
         result = self.app.storage.object_list(
             self.account_name, self.container_name, prefix=prefix,
             limit=limit, delimiter=delimiter, marker=marker,
@@ -242,7 +242,7 @@ class ContainerController(SwiftContainerController):
         headers = dict()
         out_content_type = get_listing_content_type(req)
         headers['Content-Type'] = out_content_type
-        oio_headers = {'X-oio-req-id': self.trans_id}
+        oio_headers = {REQID_HEADER: self.trans_id}
         meta = self.app.storage.container_get_properties(
             self.account_name, self.container_name, headers=oio_headers)
         headers.update(self.get_metadata_resp_headers(meta))
@@ -280,7 +280,7 @@ class ContainerController(SwiftContainerController):
     def get_container_create_resp(self, req, headers):
         properties, system = self.properties_from_headers(headers)
         # TODO container update metadata
-        oio_headers = {'X-oio-req-id': self.trans_id}
+        oio_headers = {REQID_HEADER: self.trans_id}
         created = self.app.storage.container_create(
             self.account_name, self.container_name,
             properties=properties, system=system,
@@ -373,7 +373,7 @@ class ContainerController(SwiftContainerController):
         if not properties:
             return self.PUT(req)
 
-        oio_headers = {'X-oio-req-id': self.trans_id}
+        oio_headers = {REQID_HEADER: self.trans_id}
         try:
             self.app.storage.container_set_properties(
                 self.account_name, self.container_name,
@@ -385,7 +385,7 @@ class ContainerController(SwiftContainerController):
         return resp
 
     def get_container_delete_resp(self, req):
-        oio_headers = {'X-oio-req-id': self.trans_id}
+        oio_headers = {REQID_HEADER: self.trans_id}
         try:
             self.app.storage.container_delete(
                 self.account_name, self.container_name, headers=oio_headers)

--- a/oioswift/utils.py
+++ b/oioswift/utils.py
@@ -28,6 +28,11 @@ try:
 except ImportError:
     from oio.common.exceptions import ClientException as MethodNotAllowed
 
+try:
+    from oio.common.constants import REQID_HEADER
+except ImportError:
+    REQID_HEADER = 'x-oio-req-id'
+
 
 _FORMAT_MAP = {"xml": 'application/xml', "json": 'application/json',
                "plain": 'text/plain'}
@@ -158,7 +163,7 @@ def check_if_none_match(fnc):
     def _if_none_match_wrapper(self, req, *args, **kwargs):
         if req.if_none_match is None:
             return fnc(self, req, *args, **kwargs)
-        oio_headers = {'X-oio-req-id': self.trans_id}
+        oio_headers = {REQID_HEADER: self.trans_id}
         try:
             metadata = self.app.storage.object_get_properties(
                 self.account_name, self.container_name, self.object_name,


### PR DESCRIPTION
The request ID header name was sometimes passed with an uppercase `X`, sometimes with lowercase. Now we import the proper header name from `oio` API.