### PR TITLE
CH: do not discard "empty" prefixes

### DIFF
--- a/conf/default.cfg
+++ b/conf/default.cfg
@@ -235,12 +235,11 @@ use = egg:oioswift#container_hierarchy
 #
 #redis_keys_format = v1
 
-# Enable listing and versioing with versioning listing_support:
-# by default it is disabled, enabling it will
-# trigger more listing to support shadowed prefix.
-# It will also cause issue for nonrecursive listing
-# with CloudBerry
-#support_listing_versioning = false
+# Do not display common prefixes if the only objects sharing these prefixes
+# are masked by delete markers (trying to list objects under these prefixes
+# would return nothing).
+# In previous versions, this parameter was called "support_listing_versioning".
+#mask_empty_prefixes = false
 
 [filter:bulk]
 use = egg:swift#bulk

--- a/tests/functional/common.sh
+++ b/tests/functional/common.sh
@@ -130,7 +130,7 @@ function run_functional_test() {
     configure_oioswift $conf
 
     coverage run -p runserver.py $conf -v >/tmp/journal.log 2>&1 &
-    export CONF_GW=$(readlink -e $conf)
+    export GW_CONF=$(readlink -e $conf)
     sleep 1
     PID=$(jobs -p)
 

--- a/tests/functional/s3-versioning-container-hierarchy.sh
+++ b/tests/functional/s3-versioning-container-hierarchy.sh
@@ -2,7 +2,7 @@
 
 export OIO_NS="${1:-OPENIO}"
 export OIO_ACCOUNT="${2:-AUTH_demo}"
-LISTING_VERSIONING=$(cat $CONF_GW | grep support_listing_versioning | cut -d= -f2 | sed 's/ //g' )
+MASK_EMPTY_PREFIXES=$(grep support_listing_versioning "$GW_CONF" | cut -d= -f2 | sed 's/ //g' )
 
 AWS="aws --endpoint-url http://localhost:5000 --no-verify-ssl"
 
@@ -10,7 +10,6 @@ BUCKET="bucket-ch-vers-$RANDOM"
 
 OBJ_0="/etc/magic"
 OBJ_1="/etc/passwd"
-OBJ_2="/etc/fstab"
 
 set -x
 set -e
@@ -51,14 +50,14 @@ ${AWS} s3api put-bucket-versioning --versioning-configuration Status=Enabled --b
 echo "*** Delete current version ***"
 ${AWS} s3 rm s3://${BUCKET}/path/obj
 
-if [ $LISTING_VERSIONING == "true" ]; then
+if [ "$MASK_EMPTY_PREFIXES" == "true" ]; then
     echo "*** Check redis key is not removed ***"
     RESULT="1"
-    if grep -E "^redis_keys_format.*=.*v3" $CONF_GW; then
+    if grep -E "^redis_keys_format.*=.*v3" "$GW_CONF"; then
         # v3 format
         CMD="zrank CS:AUTH_demo:${BUCKET}:cnt path/"
 	RESULT="0"
-    elif grep -E "^redis_keys_format.*=.*v2" $CONF_GW; then
+    elif grep -E "^redis_keys_format.*=.*v2" "$GW_CONF"; then
         # v2 format
         CMD="hget CS:AUTH_demo:${BUCKET}:cnt path/"
     else


### PR DESCRIPTION
In some cases, there is no need to check if there is actually something in the container: the check is done when removing objects, and if a container is empty, it is removed from the prefix database.
