### PR TITLE
Optimize bucket listing

### DIFF
--- a/tests/functional/buckets-listing.sh
+++ b/tests/functional/buckets-listing.sh
@@ -14,7 +14,7 @@ ${AWS} s3api create-bucket --bucket ${BUCKET_2}
 # Listing limit is 1000, no need to simulate a lot more containers.
 for i in ${BUCKET_1} ${BUCKET_1}%2F${SUBPATH}%2F{1..2000} ${BUCKET_2};
 do
-    echo ZADD containers:${OIO_ACCOUNT} 1 ${i};
+    echo ZADD containers:${OIO_ACCOUNT} 0 ${i};
     echo HSET container:${OIO_ACCOUNT}:${i} bytes 0;
     echo HSET container:${OIO_ACCOUNT}:${i} objects 0;
     echo HSET container:${OIO_ACCOUNT}:${i} dtime 0;

--- a/tests/functional/encryption-tests.sh
+++ b/tests/functional/encryption-tests.sh
@@ -7,7 +7,7 @@ export OIO_NS="${OIO_NS:-OPENIO}"
 export OIO_ACCOUNT="${OIO_ACCOUNT:-AUTH_demo}"
 
 AWS="aws --endpoint-url http://localhost:5000 --no-verify-ssl"
-BUCKET=bucket-$RANDOM
+BUCKET=bucket-enc-$RANDOM
 ETAG_REGEX='s/(.*ETag.*)([[:xdigit:]]{32})(.*)/\2/p'
 WORKDIR=$(mktemp -d -t encryption-tests-XXXX)
 OBJ_1_SRC="/etc/magic"

--- a/tests/functional/s3-acl-metadata.sh
+++ b/tests/functional/s3-acl-metadata.sh
@@ -2,10 +2,7 @@
 
 AWS="aws --endpoint-url http://localhost:5000 --no-verify-ssl"
 
-BUCKET=bucket-$RANDOM
-
-# AWS="aws --profil amazon"
-# BUCKET=openio.michael
+BUCKET=bucket-acl-$RANDOM
 
 echo "Bucket name: $BUCKET"
 

--- a/tests/functional/s3-conversion-container-hierarchy.sh
+++ b/tests/functional/s3-conversion-container-hierarchy.sh
@@ -3,7 +3,7 @@
 set -x
 set -e
 ACCOUNT="AUTH_demo"
-BUCKET=bucket-$RANDOM
+BUCKET=bucket-conv-$RANDOM
 REDIS_CLI="redis-cli"
 
 ${REDIS_CLI} set "CS:${ACCOUNT}:${BUCKET}:cnt:v1/" 1

--- a/tests/functional/s3-versioning-container-hierarchy.sh
+++ b/tests/functional/s3-versioning-container-hierarchy.sh
@@ -6,7 +6,7 @@ LISTING_VERSIONING=$(cat $CONF_GW | grep support_listing_versioning | cut -d= -f
 
 AWS="aws --endpoint-url http://localhost:5000 --no-verify-ssl"
 
-BUCKET="bucket-$RANDOM"
+BUCKET="bucket-ch-vers-$RANDOM"
 
 OBJ_0="/etc/magic"
 OBJ_1="/etc/passwd"

--- a/tests/functional/s3-versioning.sh
+++ b/tests/functional/s3-versioning.sh
@@ -5,7 +5,7 @@ export OIO_ACCOUNT="${2:-AUTH_demo}"
 
 AWS="aws --endpoint-url http://localhost:5000 --no-verify-ssl"
 
-BUCKET="bucket-$RANDOM"
+BUCKET="bucket-vers-$RANDOM"
 
 OBJ_0="/etc/magic"
 OBJ_1="/etc/passwd"

--- a/tests/functional/s3_container_hierarchy_v2.sh
+++ b/tests/functional/s3_container_hierarchy_v2.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 AWS="aws --endpoint-url http://localhost:5000 --no-verify-ssl"
-BUCKET=bucket-$RANDOM
+BUCKET=bucket-ch1-$RANDOM
 LISTING_VERSIONING=$(cat $CONF_GW | grep support_listing_versioning | cut -d= -f2 | sed 's/ //g' )
 
 echo "Bucket name: $BUCKET"
@@ -186,7 +186,7 @@ ${AWS} s3api head-object --bucket ${BUCKET} --key dir1/dir2/
 
 # UTF-8 PATH
 # The '?' are caused by "s3 ls": https://github.com/aws/aws-cli/issues/3902
-BUCKET_UTF8=bucket-${RANDOM}
+BUCKET_UTF8=bucket-utf8-${RANDOM}
 ${AWS} s3api create-bucket --bucket ${BUCKET_UTF8}
 ${AWS} s3 cp /etc/passwd s3://${BUCKET_UTF8}/rêve/file
 ${AWS} s3api head-object --bucket ${BUCKET_UTF8} --key rêve/file
@@ -220,8 +220,8 @@ echo -e "${DIRECTORY_LIST}" | grep "g?teau\|gâteau"
 
 # COPY S3<=>S3
 
-BCK1=bucket-${RANDOM}
-BCK2=bucket-${RANDOM}
+BCK1=bucket-copy-${RANDOM}
+BCK2=bucket-copy-${RANDOM}
 
 ${AWS} s3api create-bucket --bucket ${BCK1}
 ${AWS} s3api create-bucket --bucket ${BCK2}


### PR DESCRIPTION
When Container Hierarchy is used, a lot of containers
may be created. This patch will use first character of
encoded delimiter of Container Hierarchy as delimiter.

Since S3 doesn't support delimiter in bucket listing (and
results are not compliant with bucket name for old SDS),
we also skip `subdir` entries when generating results
(thanks to @AymericDu ), it will no require SDS update