### PR TITLE
CI: do not require system_site_packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ dist: bionic
 language: python
 python:
     - "2.7"
-virtualenv:
-    system_site_packages: true
 addons:
   apt:
     sources:


### PR DESCRIPTION
It is no more needed since oiozookeeper has been published on PyPI.